### PR TITLE
Refactored Snap hooks

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,20 +1,11 @@
 #!/bin/sh -e
 
-if [ ! -d "$SNAP_COMMON" ]; then
-    mkdir -p "$SNAP_COMMON"
-fi
+# Copy latest host to $SNAP_COMMON
 cp -RLp "$SNAP"/usr/lib/dotnet "$SNAP_COMMON"
 
-# Create an empty local manifest file if it doesn't yet exist.
-if [ ! -e "$SNAP_COMMON"/dotnet/manifest.json ]; then
-    echo "[ ]" > "$SNAP_COMMON"/dotnet/manifest.json
-fi
-
-# Update current .NET to latest versions
-DOTNET_LATEST=$(jq -r '.sdk[0]' "$SNAP"/Configuration/limits.json)
-
+# Update current .NET installs to latest version
 DOTNET_INSTALL_DIR=$SNAP_COMMON/dotnet \
     LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu \
     LIMITS_PATH=$SNAP/Configuration/limits.json \
     SERVER_URL=https://raw.githubusercontent.com/canonical/dotnet-snap/main/manifest/ \
-    "$SNAP"/Dotnet.Installer.Console install dotnet-sdk "$DOTNET_LATEST"
+    "$SNAP"/Dotnet.Installer.Console update --all

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -9,3 +9,12 @@ cp -RLp "$SNAP"/usr/lib/dotnet "$SNAP_COMMON"
 if [ ! -e "$SNAP_COMMON"/dotnet/manifest.json ]; then
     echo "[ ]" > "$SNAP_COMMON"/dotnet/manifest.json
 fi
+
+# Update current .NET to latest versions
+DOTNET_LATEST=$(jq -r '.sdk[0]' "$SNAP"/Configuration/limits.json)
+
+DOTNET_INSTALL_DIR=$SNAP_COMMON/dotnet \
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu \
+    LIMITS_PATH=$SNAP/Configuration/limits.json \
+    SERVER_URL=https://raw.githubusercontent.com/canonical/dotnet-snap/main/manifest/ \
+    "$SNAP"/Dotnet.Installer.Console install dotnet-sdk "$DOTNET_LATEST"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+
+# Create $SNAP_COMMON if doesn't exist
+if [ ! -d "$SNAP_COMMON" ]; then
+    mkdir -p "$SNAP_COMMON"
+fi
+
+# Create .NET installation directory
+mkdir "$SNAP_COMMON"/dotnet
+
+# Create an empty local manifest file if it doesn't yet exist.
+if [ ! -e "$SNAP_COMMON"/dotnet/manifest.json ]; then
+    echo "[ ]" > "$SNAP_COMMON"/dotnet/manifest.json
+fi
+
+# Install latest .NET SDK on first install
+DOTNET_LATEST=$(jq -r '.sdk[0]' "$SNAP"/Configuration/limits.json)
+DOTNET_INSTALL_DIR=$SNAP_COMMON/dotnet \
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu \
+    LIMITS_PATH=$SNAP/Configuration/limits.json \
+    SERVER_URL=https://raw.githubusercontent.com/canonical/dotnet-snap/main/manifest/ \
+    "$SNAP"/Dotnet.Installer.Console install dotnet-sdk "$DOTNET_LATEST"


### PR DESCRIPTION
The `install` hook should now be in charge of installing the latest available .NET SDK upon first installation.

The `configure` hook will make sure that the .NET Host in `$SNAP_COMMON/dotnet` is always kept up-to-date as well as invoke the .NET installer tool to update current installations to the latest version.