### PR TITLE
Install command keeps one version per micro-release

### DIFF
--- a/src/Dotnet.Installer.Console/Verbs/InstallVerb.cs
+++ b/src/Dotnet.Installer.Console/Verbs/InstallVerb.cs
@@ -1,4 +1,4 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using Dotnet.Installer.Core.Models;
 using Dotnet.Installer.Core.Types;
 using Spectre.Console;
@@ -40,7 +40,10 @@ public class InstallVerb(RootCommand rootCommand)
             switch (version)
             {
                 case "latest":
-                    // TODO: Implement 'latest' support
+                    requestedComponent = manifest.Remote
+                        .Where(c => c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase))
+                        .OrderByDescending(c => c.Version)
+                        .FirstOrDefault();
                     break;
                 default:
                     requestedComponent = manifest.Remote.FirstOrDefault(c => 

--- a/src/Dotnet.Installer.Console/Verbs/InstallVerb.cs
+++ b/src/Dotnet.Installer.Console/Verbs/InstallVerb.cs
@@ -1,4 +1,4 @@
-using System.CommandLine;
+﻿using System.CommandLine;
 using Dotnet.Installer.Core.Models;
 using Dotnet.Installer.Core.Types;
 using Spectre.Console;
@@ -59,12 +59,13 @@ public class InstallVerb(RootCommand rootCommand)
                 return;
             }
 
-            await AnsiConsole.Status()
+            await AnsiConsole
+                .Status()
                 .Spinner(Spinner.Known.Dots12)
                 .StartAsync("Thinking...", async context =>
                 {
                     requestedComponent.InstallingPackageChanged += (sender, package) =>
-                        context.Status($"Installing {package}");
+                        context.Status($"Installing {package.Name}");
 
                     await requestedComponent.Install(manifest);
                 });

--- a/src/Dotnet.Installer.Console/Verbs/UpdateVerb.cs
+++ b/src/Dotnet.Installer.Console/Verbs/UpdateVerb.cs
@@ -49,8 +49,14 @@ public class UpdateVerb(RootCommand rootCommand)
 
             foreach (var group in majorVersionGroups)
             {
-                var duplicateComponents = group.Where(c1 =>
-                    group.Count(c2 => c2.Name.Equals(c1.Name)) > 1);
+                // Components that appear duplicated in the merged component list
+                // indicate an available update, as this scenario is only possible
+                // when the local manifest contains a component that is also listed
+                // in the remote 'latest' manifest. Since their versions are not the
+                // same, they appear duplicated (each with their own versions).
+                var duplicateComponents = group
+                    .Where(c1 => group
+                        .Count(c2 => c2.Name.Equals(c1.Name)) > 1);
                 componentsWithUpdates.AddRange(duplicateComponents);
             }
 
@@ -59,9 +65,10 @@ public class UpdateVerb(RootCommand rootCommand)
                 AnsiConsole.WriteLine("There are no updates available.");
             }
 
-            await AnsiConsole.Status()
+            await AnsiConsole
+                .Status()
                 .Spinner(Spinner.Known.Dots12)
-                .StartAsync("Thinking...", async context => 
+                .StartAsync("Thinking...", async context =>
                 {
                     foreach (var versionGroup in componentsWithUpdates.GroupBy(c => c.Version.Major))
                     {


### PR DESCRIPTION
This PR introduces behavior to the `install` command such that when installing a component (a runtime or an SDK), it will automatically remove older versions by the following logic:

- Runtime versions are kept one per major version, e.g. 8.0.2 (uninstalls 8.0.0 or 8.0.1)
- SDK versions are kept one per feature band, e.g. 8.0.201 (uninstalls 8.0.200, but keeps 8.0.102)