### PR TITLE
Add revision support to versioning

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,11 +15,6 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: classic
 
-package-repositories:
-  - type: apt
-    ppa: dotnet/dotnet8
-    priority: always
-
 parts:
   dotnet-installer:
     plugin: dotnet

--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -50,7 +50,7 @@ public class InstallCommand : Command
                         .MaxBy(c => c.Version),
                     _ => _manifestService.Remote.FirstOrDefault(c =>
                         c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase) &&
-                        c.Version == DotnetVersion.Parse(version))
+                        c.Version.Equals(DotnetVersion.Parse(version), DotnetVersionComparison.IgnoreRevision))
                 };
 
                 if (requestedComponent is null)

--- a/src/Dotnet.Installer.Console/Commands/ListCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/ListCommand.cs
@@ -48,22 +48,24 @@ public class ListCommand : Command
                     var componentHasPreviousVersionInstalled = false;
                     foreach (var component in orderedComponents)
                     {
+                        var version = component.Version.ToString().Split('+').First();
+
                         if (component.Installation is not null)
                         {
                             componentHasPreviousVersionInstalled = true;
-                            stringBuilder.Append($" [[{component.Version}");
+                            stringBuilder.Append($" [[{version}");
                             stringBuilder.Append(" [bold green]Installed :check_mark_button:[/]");
                             stringBuilder.Append("]]");
                         }
                         else if (component.Installation is null && orderedComponents.Count > 1 && componentHasPreviousVersionInstalled)
                         {
-                            stringBuilder.Append($" \u2192 [[{component.Version}");
+                            stringBuilder.Append($" \u2192 [[{version}");
                             stringBuilder.Append(" [bold yellow]Update available![/]");
                             stringBuilder.Append("]]");
                         }
                         else
                         {
-                            stringBuilder.Append($" [[{component.Version}]]");
+                            stringBuilder.Append($" [[{version}]]");
                         }
                     }
                     

--- a/src/Dotnet.Installer.Console/Commands/RemoveCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/RemoveCommand.cs
@@ -51,7 +51,7 @@ public class RemoveCommand : Command
                 var requestedVersion = DotnetVersion.Parse(version);
                 var requestedComponent = _manifestService.Local.FirstOrDefault(c => 
                     c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase)
-                    && c.Version == requestedVersion);
+                    && c.Version.Equals(requestedVersion, DotnetVersionComparison.IgnoreRevision));
 
                 if (requestedComponent is null)
                 {

--- a/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
@@ -100,12 +100,22 @@ public class UpdateCommand : Command
                                 context.Status(
                                     $"Updating {toUninstall.Name} from {toUninstall.Version} to {toInstall.Version}...");
 
-                                await toInstall.Install(_fileService, _limitsService, _manifestService);
-                                await toUninstall.Uninstall(_fileService, _manifestService);
-
-                                context.Status("[green]Update complete :check_mark_button:[/]");
+                                if (toInstall.CanInstall(_limitsService))
+                                {
+                                    await toUninstall.Uninstall(_fileService, _manifestService);
+                                    await toInstall.Install(_fileService, _limitsService, _manifestService);
+                                }
+                                else
+                                {
+                                    throw new VersionTooHighException(toInstall,
+                                        toInstall.Version.IsRuntime
+                                            ? _limitsService.Runtime
+                                            : _limitsService.Sdk.First(v => v.FeatureBand == toInstall.Version.FeatureBand));
+                                }
                             }
                         }
+
+                        context.Status("[green]Update complete :check_mark_button:[/]");
                     });
 
                 return;

--- a/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
@@ -27,8 +27,7 @@ public class UpdateCommand : Command
             };
         var allOption = new Option<bool>(
             name: "--all",
-            description: "Updates all components with updates available."
-        );
+            description: "Updates all components with updates available.");
         AddArgument(componentArgument);
         AddOption(allOption);
 
@@ -101,8 +100,8 @@ public class UpdateCommand : Command
                                 context.Status(
                                     $"Updating {toUninstall.Name} from {toUninstall.Version} to {toInstall.Version}...");
 
-                                await toUninstall.Uninstall(_fileService, _manifestService);
                                 await toInstall.Install(_fileService, _limitsService, _manifestService);
+                                await toUninstall.Uninstall(_fileService, _manifestService);
 
                                 context.Status("[green]Update complete :check_mark_button:[/]");
                             }

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using Dotnet.Installer.Core.Exceptions;
 using Dotnet.Installer.Core.Models.Events;
 using Dotnet.Installer.Core.Services.Contracts;
@@ -21,7 +21,7 @@ public class Component
     public event EventHandler<InstallationFinishedEventArgs>? InstallationFinished;
     public event EventHandler<InstallingPackageChangedEventArgs>? InstallingPackageChanged;
 
-    private bool CanInstall(ILimitsService limitsService)
+    public bool CanInstall(ILimitsService limitsService)
     {
         if (Version.IsRuntime)
         {

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Dotnet.Installer.Core.Exceptions;
 using Dotnet.Installer.Core.Models.Events;
 using Dotnet.Installer.Core.Services.Contracts;
@@ -66,8 +66,9 @@ public class Component
             // within the major version/feature band group, uninstall it.
             var previousComponent = manifestService.Local
                 .FirstOrDefault(c => c.Name.Equals(Name, StringComparison.CurrentCultureIgnoreCase)
-                    && c.Version.IsRuntime ? c.Version < Version :
-                        c.Version.FeatureBand == Version.FeatureBand && c.Version < Version);
+                    && (c.Version.IsRuntime
+                            ? c.Version < Version
+                            : (c.Version.FeatureBand == Version.FeatureBand && c.Version < Version)));
 
             if (previousComponent is not null)
             {

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -61,19 +61,6 @@ public class Component
         if (Installation is null)
         {
             InstallationStarted?.Invoke(this, new InstallationStartedEventArgs(Key));
-
-            // If this component already has a previous version installed
-            // within the major version/feature band group, uninstall it.
-            var previousComponent = manifestService.Local
-                .FirstOrDefault(c => c.Name.Equals(Name, StringComparison.CurrentCultureIgnoreCase)
-                    && (c.Version.IsRuntime
-                            ? c.Version < Version
-                            : (c.Version.FeatureBand == Version.FeatureBand && c.Version < Version)));
-
-            if (previousComponent is not null)
-            {
-                await previousComponent.Uninstall(fileService, manifestService);
-            }
             
             // Install component packages
             foreach (var package in Packages)

--- a/src/Dotnet.Installer.Core/Services/Implementations/LimitsService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/LimitsService.cs
@@ -21,5 +21,15 @@ public class LimitsService : ILimitsService
 
         Runtime = limits.RootElement.GetProperty("runtime").Deserialize<DotnetVersion>()!;
         Sdk = limits.RootElement.GetProperty("sdk").Deserialize<IEnumerable<DotnetVersion>>()!;
+
+        // Max out the revision to avoid installations failing when a new revision
+        // comes out and the comparison between e.g. 8.0.101+1 <= 8.0.101 fails
+        // when assessing whether that specific version can be installed with
+        // the current host.
+        Runtime.Revision = int.MaxValue;
+        foreach (var sdkVersion in Sdk)
+        {
+            sdkVersion.Revision = int.MaxValue;
+        }
     }
 }

--- a/src/Dotnet.Installer.Core/Types/DotnetVersion.Operators.cs
+++ b/src/Dotnet.Installer.Core/Types/DotnetVersion.Operators.cs
@@ -44,10 +44,25 @@ public partial class DotnetVersion
         if (GetType() != other.GetType()) return false;
 
         return (Major == other.Major) && (Minor == other.Minor) && (Patch == other.Patch) &&
-               (IsPreview == other.IsPreview) && (IsRc == other.IsRc) && (PreviewIdentifier == other.PreviewIdentifier);
+               (IsPreview == other.IsPreview) && (IsRc == other.IsRc) && (PreviewIdentifier == other.PreviewIdentifier) &&
+               (Revision == other.Revision);
     }
 
-    public override int GetHashCode() => (Major, Minor, Patch).GetHashCode();
+    public override int GetHashCode()
+    {
+        unchecked // Overflow is fine, just wrap
+        {
+            int hash = 17;
+            hash = hash * 23 + Major.GetHashCode();
+            hash = hash * 23 + Minor.GetHashCode();
+            hash = hash * 23 + Patch.GetHashCode();
+            hash = hash * 23 + IsPreview.GetHashCode();
+            hash = hash * 23 + IsRc.GetHashCode();
+            hash = hash * 23 + (PreviewIdentifier?.GetHashCode() ?? 0);
+            hash = hash * 23 + (Revision?.GetHashCode() ?? 0);
+            return hash;
+        }
+    }
 
     public static bool operator ==(DotnetVersion? lhs, DotnetVersion? rhs)
     {

--- a/src/Dotnet.Installer.Core/Types/DotnetVersion.Operators.cs
+++ b/src/Dotnet.Installer.Core/Types/DotnetVersion.Operators.cs
@@ -18,12 +18,14 @@ public partial class DotnetVersion
         if (other.IsPreview && IsRc) return 1;
         if (other.IsRc && IsPreview) return -1;
 
-        return IsStable switch
-        {
-            true when !other.IsStable => 1,
-            false when other.IsStable => -1,
-            _ => 0
-        };
+        if (IsStable && !other.IsStable) return 1;
+        if (!IsStable && other.IsStable) return -1;
+
+        // It will come down to revisions then
+        if (Revision.HasValue && !other.Revision.HasValue) return 1;
+        else if (!Revision.HasValue && other.Revision.HasValue) return -1;
+        else if (!Revision.HasValue && !other.Revision.HasValue) return 0;
+        else return Revision!.Value - other.Revision!.Value;
     }
 
     public static bool operator <(DotnetVersion lhs, DotnetVersion rhs) => lhs.CompareTo(rhs) < 0;

--- a/src/Dotnet.Installer.Core/Types/DotnetVersion.Operators.cs
+++ b/src/Dotnet.Installer.Core/Types/DotnetVersion.Operators.cs
@@ -48,6 +48,28 @@ public partial class DotnetVersion
                (Revision == other.Revision);
     }
 
+    public bool Equals(DotnetVersion? other, DotnetVersionComparison comparisonType)
+        => Equals(this, other, comparisonType);
+
+    public static bool Equals(DotnetVersion? rhs, DotnetVersion? lhs,
+        DotnetVersionComparison comparisonType = DotnetVersionComparison.Default)
+    {
+        if (rhs is null || lhs is null) return rhs == lhs;
+
+        return comparisonType switch
+        {
+            DotnetVersionComparison.IgnoreRevision =>
+                (lhs.Major == rhs.Major) &&
+                (lhs.Minor == rhs.Minor) &&
+                (lhs.Patch == rhs.Patch) &&
+                (lhs.IsPreview == rhs.IsPreview) &&
+                (lhs.IsRc == rhs.IsRc) &&
+                (lhs.PreviewIdentifier == rhs.PreviewIdentifier),
+
+            _ => rhs.Equals(lhs),
+        };
+    }
+
     public override int GetHashCode()
     {
         unchecked // Overflow is fine, just wrap

--- a/src/Dotnet.Installer.Core/Types/DotnetVersionComparison.cs
+++ b/src/Dotnet.Installer.Core/Types/DotnetVersionComparison.cs
@@ -1,0 +1,7 @@
+﻿namespace Dotnet.Installer.Core.Types;
+
+public enum DotnetVersionComparison
+{
+    Default,
+    IgnoreRevision
+}

--- a/tests/Dotnet.Installer.Core.Tests/Services/Implementations/LimitsServiceTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Services/Implementations/LimitsServiceTests.cs
@@ -33,10 +33,10 @@ public class LimitsServiceTests
         var limitsService = new LimitsService(fileServiceMock.Object);
         
         // Assert
-        Assert.Equal(new DotnetVersion(8, 0, 3), limitsService.Runtime);
+        Assert.Equal(new DotnetVersion(8, 0, 3, revision: int.MaxValue), limitsService.Runtime);
         Assert.True(limitsService.Sdk.Count() == 2);
-        Assert.Contains(new DotnetVersion(8, 0, 103), limitsService.Sdk);
-        Assert.Contains(new DotnetVersion(8, 0, 201), limitsService.Sdk);
+        Assert.Contains(new DotnetVersion(8, 0, 103, revision: int.MaxValue), limitsService.Sdk);
+        Assert.Contains(new DotnetVersion(8, 0, 201, revision: int.MaxValue), limitsService.Sdk);
     }
 
     [Fact]

--- a/tests/Dotnet.Installer.Core.Tests/Types/DotnetVersionOperatorsTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Types/DotnetVersionOperatorsTests.cs
@@ -151,6 +151,77 @@ public class DotnetVersionOperatorsTests
         Assert.True(result2);
     }
 
+    [Fact]
+    public void StaticEquals_WithOneVersionNull_ShouldCompareCorrectly()
+    {
+        // Arrange
+        var version1 = new DotnetVersion(8, 0, 0);
+        var version2 = default(DotnetVersion);
+
+        var version3 = default(DotnetVersion);
+        var version4 = new DotnetVersion(8, 0, 103);
+
+        // Act
+        var different1 = DotnetVersion.Equals(version1, version2);
+        var different2 = DotnetVersion.Equals(version3, version4);
+
+        // Assert
+        Assert.False(different1);
+        Assert.False(different2);
+    }
+
+    [Fact]
+    public void StaticEquals_WithBothVersionsNull_ShouldCompareCorrectly()
+    {
+        // Arrange
+        var version1 = default(DotnetVersion);
+        var version2 = default(DotnetVersion);
+
+        // Act
+        var equal = DotnetVersion.Equals(version1, version2);
+
+        // Assert
+        Assert.True(equal);
+    }
+
+    [Fact]
+    public void StaticEquals_WithDefaultComparisonType_ShouldCompareCorrectly()
+    {
+        // Arrange
+        var version1 = new DotnetVersion(8, 0, 0);
+        var version2 = new DotnetVersion(8, 0, 0);
+
+        var version3 = new DotnetVersion(8, 0, 100);
+        var version4 = new DotnetVersion(8, 0, 103);
+
+        // Act
+        var equal = DotnetVersion.Equals(version1, version2, DotnetVersionComparison.Default);
+        var different = DotnetVersion.Equals(version3, version4, DotnetVersionComparison.Default);
+
+        // Assert
+        Assert.True(equal);
+        Assert.False(different);
+    }
+
+    [Fact]
+    public void StaticEquals_WithIgnoreRevisionComparisonType_ShouldCompareCorrectly()
+    {
+        // Arrange
+        var version1 = new DotnetVersion(8, 0, 0, revision: 2);
+        var version2 = new DotnetVersion(8, 0, 0, revision: 3);
+
+        var version3 = new DotnetVersion(8, 0, 100, revision: 4);
+        var version4 = new DotnetVersion(8, 0, 103, revision: 5);
+
+        // Act
+        var equal = DotnetVersion.Equals(version1, version2, DotnetVersionComparison.IgnoreRevision);
+        var different = DotnetVersion.Equals(version3, version4, DotnetVersionComparison.IgnoreRevision);
+
+        // Assert
+        Assert.True(equal);
+        Assert.False(different);
+    }
+
     [Theory]
     [InlineData(8, 0, 0, false, true, 2, null)]
     public void GetHashCode_WithEqualObjects_ShouldReturnTheSame(int major, int minor, int patch,

--- a/tests/Dotnet.Installer.Core.Tests/Types/DotnetVersionOperatorsTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Types/DotnetVersionOperatorsTests.cs
@@ -113,16 +113,24 @@ public class DotnetVersionOperatorsTests
         
         var version3 = new DotnetVersion(8, 0, 102);
         var version4 = new DotnetVersion(8, 0, 104);
+
+        var version5 = new DotnetVersion(8, 0, 102, revision: 1);
+        var version6 = new DotnetVersion(8, 0, 102, revision: null);
         
         // Act
         var result1 = version1.Equals(version2);
         var result2 = version3.Equals(version4);
+        var result3 = version5.Equals(version6);
         
         // Assert
         Assert.False(result1);
         Assert.False(result2);
+        Assert.False(result3);
+
         Assert.False(version1 == version2);
         Assert.False(version3 == version4);
+        Assert.False(version5 == version6);
+
         Assert.False(version1.Equals(null));
     }
 
@@ -141,5 +149,48 @@ public class DotnetVersionOperatorsTests
         // Assert
         Assert.False(result1);
         Assert.True(result2);
+    }
+
+    [Theory]
+    [InlineData(8, 0, 0, false, true, 2, null)]
+    public void GetHashCode_WithEqualObjects_ShouldReturnTheSame(int major, int minor, int patch,
+        bool isPreview, bool isRc, int? previewIdentifier, int? revision)
+    {
+        // Arrange
+        var version1 = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier, revision);
+        var version2 = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier, revision);
+
+        // Act
+        var hash1 = version1.GetHashCode();
+        var hash2 = version2.GetHashCode();
+
+        // Assert
+        Assert.Equal(hash1, hash2);
+        Assert.True(version1 == version2);
+    }
+
+    [Fact]
+    public void GetHashCode_WithDifferentObjects_ShouldReturnDifferentHashes()
+    {
+        // Arrange
+        var version1 = new DotnetVersion(8, 0, 0);
+        var version2 = new DotnetVersion(8, 0, 0, revision: 1);
+
+        var version3 = new DotnetVersion(8, 0, 100, true, false, 2);
+        var version4 = new DotnetVersion(8, 0, 3, revision: 1);
+
+        // Act
+        var hash1 = version1.GetHashCode();
+        var hash2 = version2.GetHashCode();
+
+        var hash3 = version3.GetHashCode();
+        var hash4 = version4.GetHashCode();
+
+        // Assert
+        Assert.NotEqual(hash1, hash2);
+        Assert.NotEqual(hash3, hash4);
+
+        Assert.False(version1 == version2);
+        Assert.False(version3 == version4);
     }
 }

--- a/tests/Dotnet.Installer.Core.Tests/Types/DotnetVersionOperatorsTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Types/DotnetVersionOperatorsTests.cs
@@ -5,52 +5,61 @@ namespace Dotnet.Installer.Core.Tests.Types;
 public class DotnetVersionOperatorsTests
 {
     [Theory]
-    [InlineData(8, 0, 100, false, false, null)]
-    [InlineData(8, 0, 101, true, false, 2)]
-    [InlineData(8, 0, 101, false, true, 1)]
+    [InlineData(8, 0, 100, false, false, null, null)]
+    [InlineData(8, 0, 101, true, false, 2, null)]
+    [InlineData(8, 0, 101, false, true, 1, null)]
+    [InlineData(8, 0, 100, false, true, 1, 2)]
+    [InlineData(8, 0, 101, false, false, null, 1)]
     public void CompareTo_WithLowerVersion_ShouldReturnGreaterThanZero(int major, int minor, int patch, bool isPreview,
-        bool isRc, int? previewIdentifier)
+        bool isRc, int? previewIdentifier, int? revision)
     {
         // Arrange
-        var higherVersion = new DotnetVersion(8, 0, 101);
-        var lowerVersion = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier);
+        var higherVersion1 = new DotnetVersion(8, 0, 101, revision: 3);
+        var higherVersion2 = new DotnetVersion(8, 0, 102);
+        var lowerVersion = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier, revision);
 
         // Act
-        var result = higherVersion.CompareTo(lowerVersion);
+        var result1 = higherVersion1.CompareTo(lowerVersion);
+        var result2 = higherVersion2.CompareTo(lowerVersion);
 
         // Assert
-        Assert.True(result > 0);
+        Assert.True(result1 > 0);
+        Assert.True(result2 > 0);
     }
 
     [Theory]
-    [InlineData(8, 0, 102, false, false, null)]
-    [InlineData(8, 0, 100, true, false, 3)]
-    [InlineData(8, 0, 100, false, true, 1)]
+    [InlineData(8, 0, 102, false, false, null, null)]
+    [InlineData(8, 0, 100, true, false, 3, null)]
+    [InlineData(8, 0, 100, false, true, 1, null)]
+    [InlineData(8, 0, 103, false, false, null, 1)]
     public void CompareTo_WithHigherVersion_ShouldReturnSmallerThanZero(int major, int minor, int patch, bool isPreview,
-        bool isRc, int? previewIdentifier)
+        bool isRc, int? previewIdentifier, int? revision)
     {
         // Arrange
-        var higherVersion = new DotnetVersion(8, 0, 103);
-        var lowerVersion = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier);
+        var higherVersion1 = new DotnetVersion(8, 0, 103, revision: 2);
+        var higherVersion2 = new DotnetVersion(8, 0, 104);
+        var lowerVersion = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier, revision);
 
         // Act
-        var result = lowerVersion.CompareTo(higherVersion);
+        var result1 = lowerVersion.CompareTo(higherVersion1);
+        var result2 = lowerVersion.CompareTo(higherVersion2);
 
         // Assert
-        Assert.True(result < 0);
+        Assert.True(result1 < 0);
+        Assert.True(result2 < 0);
         Assert.True(lowerVersion.CompareTo(null) < 0);
     }
 
     [Theory]
-    [InlineData(8, 0, 102, false, false, null)]
-    [InlineData(8, 0, 100, true, false, 3)]
-    [InlineData(8, 0, 100, false, true, 1)]
+    [InlineData(8, 0, 102, false, false, null, 1)]
+    [InlineData(8, 0, 100, true, false, 3, 2)]
+    [InlineData(8, 0, 100, false, true, 1, null)]
     public void CompareTo_WithEqualVersion_ShouldReturnZero(int major, int minor, int patch, bool isPreview,
-        bool isRc, int? previewIdentifier)
+        bool isRc, int? previewIdentifier, int? revision)
     {
         // Arrange
-        var version1 = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier);
-        var version2 = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier);
+        var version1 = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier, revision);
+        var version2 = new DotnetVersion(major, minor, patch, isPreview, isRc, previewIdentifier, revision);
 
         // Act
         var result = version1.CompareTo(version2);
@@ -90,6 +99,8 @@ public class DotnetVersionOperatorsTests
         // Assert
         Assert.True(result1);
         Assert.True(result2);
+        Assert.True(version1 == version2);
+        Assert.True(version3 == version4);
         Assert.True(version1.Equals(version1));
     }
     
@@ -110,6 +121,25 @@ public class DotnetVersionOperatorsTests
         // Assert
         Assert.False(result1);
         Assert.False(result2);
+        Assert.False(version1 == version2);
+        Assert.False(version3 == version4);
         Assert.False(version1.Equals(null));
+    }
+
+    [Fact]
+    public void Equals_WithAnyOrBothVersionsNull_ShouldReturnTrue()
+    {
+        // Arrange
+        var version1 = new DotnetVersion(8, 0, 100, false, false, null);
+        var version2 = default(DotnetVersion);
+        var version3 = default(DotnetVersion);
+
+        // Act
+        var result1 = version1 == version2;
+        var result2 = version2 == version3;
+
+        // Assert
+        Assert.False(result1);
+        Assert.True(result2);
     }
 }


### PR DESCRIPTION
This PR adds revision support to component versioning. This will allow the release of updates when the upstream .NET version of a component does not change.

## How it works

Revision works by appending a `+<number>` to the end of the version string of a component, e.g.

```
   {
      "key": "aspnetcore-runtime-8.0.3+2",
      "name": "aspnetcore-runtime",
      "description": "ASP.NET Core",
      "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
      "version": "8.0.3+2",
      "packages": [
         {
            "name": "aspnetcore-runtime-8.0",
            "version": "8.0.3-0ubuntu1~22.04.1"
         }
      ],
      "dependencies": [
         "dotnet-runtime-8.0.3+2"
      ]
   }
```

Since the `key` is a unique parameter, it should also be updated to include the revision to avoid any collisions when merging local and remote manifests.

Any dependency key strings also need updating when the key of a dependent component changes.

## Ordering

Revision is an optional parameter, therefore a version `8.0.3` has a revision of `null`. Subsequently, any `+<number>` appended to the end of a version string changes the version to have a revision of `<number>`.

Null revisions take precedence in ordering, such as:

```
8.0.3 < 8.0.3+2 < 8.0.3+256 < 8.0.4
```