### PR TITLE
Keep snap-related files under snap directory in $SNAP_COMMON

### DIFF
--- a/Dotnet.Installer.sln
+++ b/Dotnet.Installer.sln
@@ -17,6 +17,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "hooks", "hooks", "{0CDB7334-6495-4660-80A9-EB89241FD28D}"
 	ProjectSection(SolutionItems) = preProject
 		snap\hooks\configure = snap\hooks\configure
+		snap\hooks\install = snap\hooks\install
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{BC2751F8-2768-47A6-AA22-04EEFA92CE88}"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -7,10 +7,12 @@ fi
 
 # Create .NET installation directory
 mkdir "$SNAP_COMMON"/dotnet
+# Create snap configuration directory
+mkdir "$SNAP_COMMON"/snap
 
 # Create an empty local manifest file if it doesn't yet exist.
-if [ ! -e "$SNAP_COMMON"/dotnet/manifest.json ]; then
-    echo "[ ]" > "$SNAP_COMMON"/dotnet/manifest.json
+if [ ! -e "$SNAP_COMMON"/snap/manifest.json ]; then
+    echo "[ ]" > "$SNAP_COMMON"/snap/manifest.json
 fi
 
 # Install latest .NET SDK on first install

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -14,9 +14,8 @@ if [ ! -e "$SNAP_COMMON"/dotnet/manifest.json ]; then
 fi
 
 # Install latest .NET SDK on first install
-DOTNET_LATEST=$(jq -r '.sdk[0]' "$SNAP"/Configuration/limits.json)
 DOTNET_INSTALL_DIR=$SNAP_COMMON/dotnet \
     LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu \
     LIMITS_PATH=$SNAP/Configuration/limits.json \
     SERVER_URL=https://raw.githubusercontent.com/canonical/dotnet-snap/main/manifest/ \
-    "$SNAP"/Dotnet.Installer.Console install dotnet-sdk "$DOTNET_LATEST"
+    "$SNAP"/Dotnet.Installer.Console install dotnet-sdk latest

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -71,7 +71,7 @@ public class Component
 
                 var filePath = await fileService.DownloadFile(debUrl, manifestService.DotnetInstallLocation);
 
-                await fileService.ExtractDeb(filePath, manifestService.DotnetInstallLocation);
+                await fileService.ExtractDeb(filePath, manifestService.DotnetInstallLocation, manifestService.SnapConfigurationLocation);
 
                 fileService.DeleteFile(filePath);
             }
@@ -99,7 +99,7 @@ public class Component
         {
             foreach (var package in Packages)
             {
-                var registrationFileName = Path.Combine(manifestService.DotnetInstallLocation, 
+                var registrationFileName = Path.Combine(manifestService.SnapConfigurationLocation, 
                     $"{package.Name}.files");
 
                 if (!fileService.FileExists(registrationFileName))

--- a/src/Dotnet.Installer.Core/Services/Contracts/IFileService.cs
+++ b/src/Dotnet.Installer.Core/Services/Contracts/IFileService.cs
@@ -5,7 +5,7 @@ public interface IFileService
     void DeleteFile(string path);
     Task<string> DownloadFile(Uri url, string destinationDirectory);
     bool FileExists(string path);
-    Task ExtractDeb(string debPath, string destinationDirectory);
+    Task ExtractDeb(string debPath, string destinationDirectory, string snapConfigurationDirectory);
     Task<string> GetFileHash(string filePath);
     IEnumerable<string> MoveDirectory(string sourceDirectory, string destinationDirectory);
     Stream OpenRead(string path);

--- a/src/Dotnet.Installer.Core/Services/Contracts/IManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Contracts/IManifestService.cs
@@ -4,6 +4,7 @@ namespace Dotnet.Installer.Core.Services.Contracts;
 
 public interface IManifestService
 {
+    string SnapConfigurationLocation { get; }
     string DotnetInstallLocation { get; }
 
     IEnumerable<Component> Local { get; }

--- a/src/Dotnet.Installer.Core/Services/Implementations/FileService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/FileService.cs
@@ -38,7 +38,7 @@ public class FileService : IFileService
         return File.Exists(path);
     }
 
-    public async Task ExtractDeb(string debPath, string destinationDirectory)
+    public async Task ExtractDeb(string debPath, string destinationDirectory, string snapConfigurationDirectory)
     {
         var scratchDirectory = Path.Combine(destinationDirectory, "scratch");
 
@@ -50,7 +50,7 @@ public class FileService : IFileService
         var files = MoveDirectory($"{scratchDirectory}/usr/lib/dotnet", destinationDirectory);
 
         var packageName = Path.GetFileNameWithoutExtension(debPath).Split('_').First();
-        await SavePackageContentToFile(files, destinationDirectory, packageName);
+        await SavePackageContentToFile(files, snapConfigurationDirectory, packageName);
 
         Directory.Delete(scratchDirectory, recursive: true);
     }
@@ -138,9 +138,9 @@ public class FileService : IFileService
         return Directory.GetFiles(path).Length == 0 && Directory.GetDirectories(path).Length == 0;
     }
     
-    private static async Task SavePackageContentToFile(IEnumerable<string> files, string installationDirectory, string packageName)
+    private static async Task SavePackageContentToFile(IEnumerable<string> files, string snapConfigurationDirectory, string packageName)
     {
-        var registrationFile = Path.Combine(installationDirectory, $"{packageName}.files");
+        var registrationFile = Path.Combine(snapConfigurationDirectory, $"{packageName}.files");
         await File.WriteAllLinesAsync(registrationFile, files);
     }
 }

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
@@ -8,8 +8,10 @@ namespace Dotnet.Installer.Core.Services.Implementations;
 
 public partial class ManifestService
 {
-    private static readonly string LocalManifestPath = 
-        Path.Join(Environment.GetEnvironmentVariable("DOTNET_INSTALL_DIR"), "manifest.json");
+    private static readonly string SnapConfigPath = Path.Join(
+        Environment.GetEnvironmentVariable("DOTNET_INSTALL_DIR"), "..", "snap");
+
+    private static readonly string LocalManifestPath = Path.Join(SnapConfigPath, "manifest.json");
     
     private static readonly string[] SupportedVersions = ["6.0", "7.0", "8.0"];
     

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
@@ -15,6 +15,7 @@ public partial class ManifestService : IManifestService
     private List<Component> _remote = [];
     private List<Component> _merged = [];
 
+    public string SnapConfigurationLocation => SnapConfigPath;
     public string DotnetInstallLocation =>
         Environment.GetEnvironmentVariable("DOTNET_INSTALL_DIR") 
             ?? throw new ApplicationException("DOTNET_INSTALL_DIR is not set.");

--- a/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
@@ -257,7 +257,8 @@ public class ComponentTests
         var manifestService = new Mock<IManifestService>();
 
         fileService.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
-        manifestService.Setup(m => m.DotnetInstallLocation).Returns("test");
+        manifestService.Setup(m => m.DotnetInstallLocation).Returns("dotnet_install_path");
+        manifestService.Setup(m => m.SnapConfigurationLocation).Returns("snap_config_location");
         manifestService.Setup(m => m.Remove(It.IsAny<Component>(), CancellationToken.None))
             .Callback((Component c, CancellationToken cancellationToken) =>
             {
@@ -297,7 +298,8 @@ public class ComponentTests
         var manifestService = new Mock<IManifestService>();
 
         fileService.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
-        manifestService.Setup(m => m.DotnetInstallLocation).Returns("test");
+        manifestService.Setup(m => m.DotnetInstallLocation).Returns("dotnet_install_path");
+        manifestService.Setup(m => m.SnapConfigurationLocation).Returns("snap_config_location");
 
         // Assert
         await Assert.ThrowsAsync<ApplicationException>(() =>


### PR DESCRIPTION
Snap-related files such as package file registrations and the local manifest are now kept inside `$SNAP_COMMON/snap`, so as not to pollute the .NET install directory with files that are unrelated to .NET itself.