### PR TITLE
Simplify commands + bug squashing

### DIFF
--- a/manifest/6.0/archive.json
+++ b/manifest/6.0/archive.json
@@ -31,7 +31,7 @@
     },
     {
         "key": "dotnet-sdk-6.0.124",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "6.0.124",
@@ -93,7 +93,7 @@
     },
     {
         "key": "dotnet-sdk-6.0.125",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "6.0.125",
@@ -155,7 +155,7 @@
     },
     {
         "key": "dotnet-sdk-6.0.126",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "6.0.126",
@@ -217,7 +217,7 @@
      },
      {
         "key": "dotnet-sdk-6.0.127",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "6.0.127",

--- a/manifest/7.0/archive.json
+++ b/manifest/7.0/archive.json
@@ -31,7 +31,7 @@
     },
     {
         "key": "dotnet-sdk-7.0.113",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "7.0.113",
@@ -93,7 +93,7 @@
     },
     {
         "key": "dotnet-sdk-7.0.114",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "7.0.114",
@@ -155,7 +155,7 @@
     },
     {
         "key": "dotnet-sdk-7.0.115",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "7.0.115",
@@ -217,7 +217,7 @@
      },
      {
         "key": "dotnet-sdk-7.0.116",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "7.0.116",

--- a/manifest/8.0/archive.json
+++ b/manifest/8.0/archive.json
@@ -31,7 +31,7 @@
     },
     {
         "key": "dotnet-sdk-8.0.100",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "8.0.100",
@@ -93,7 +93,7 @@
     },
     {
         "key": "dotnet-sdk-8.0.101",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "8.0.101",
@@ -155,7 +155,7 @@
      },
      {
         "key": "dotnet-sdk-8.0.102",
-        "name": "dotnet-sdk",
+        "name": "sdk",
         "description": "SDK",
         "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
         "version": "8.0.102",

--- a/manifest/latest.json
+++ b/manifest/latest.json
@@ -31,7 +31,7 @@
    },
    {
       "key": "dotnet-sdk-6.0.128",
-      "name": "dotnet-sdk",
+      "name": "sdk",
       "description": "SDK",
       "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
       "version": "6.0.128",
@@ -93,7 +93,7 @@
    },
    {
       "key": "dotnet-sdk-7.0.117",
-      "name": "dotnet-sdk",
+      "name": "sdk",
       "description": "SDK",
       "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
       "version": "7.0.117",
@@ -155,7 +155,7 @@
    },
    {
       "key": "dotnet-sdk-8.0.103",
-      "name": "dotnet-sdk",
+      "name": "sdk",
       "description": "SDK",
       "baseUrl": "https://launchpad.net/ubuntu/+archive/primary/+files/",
       "version": "8.0.103",

--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -1,4 +1,4 @@
-using System.CommandLine;
+﻿using System.CommandLine;
 using Dotnet.Installer.Core.Exceptions;
 using Dotnet.Installer.Core.Models;
 using Dotnet.Installer.Core.Services.Contracts;
@@ -82,7 +82,7 @@ public class InstallCommand : Command
                     .StartAsync("Thinking...", async context =>
                     {
                         requestedComponent.InstallingPackageChanged += (sender, args) =>
-                            context.Status($"Installing {args.Package.Name}");
+                            context.Status($"Installing {args.Package.Name} {args.Component.Version}");
 
                         await requestedComponent.Install(_fileService, _limitsService, _manifestService);
                     });

--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -47,11 +47,20 @@ public class InstallCommand : Command
                 Component? MatchVersion()
                 {
                     if (string.IsNullOrWhiteSpace(version)) return default;
-                    else if (version.Length == 1)
+                    else if (version.Length == 1) // Major version only, e.g. install sdk 8
                     {
                         return _manifestService.Remote
                             .Where(c => 
                                 c.Version.Major == int.Parse(version) &&
+                                c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase))
+                            .MaxBy(c => c.Version);
+                    }
+                    else if (version.Length == 3) // Major and minor version only, e.g install sdk 8.0
+                    {
+                        return _manifestService.Remote
+                            .Where(c =>                                         // "8.0"
+                                c.Version.Major == int.Parse(version[..1]) &&   // "8"
+                                c.Version.Minor == int.Parse(version[2..3]) &&  // "0"
                                 c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase))
                             .MaxBy(c => c.Version);
                     }

--- a/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
@@ -19,32 +19,13 @@ public class UpdateCommand : Command
         _limitsService = limitsService ?? throw new ArgumentNullException(nameof(limitsService));
         _manifestService = manifestService ?? throw new ArgumentNullException(nameof(manifestService));
 
-        var componentArgument = new Argument<string>(
-            name: "component",
-            description: "The .NET component name to be updated (dotnet-runtime, aspnetcore-runtime, runtime, sdk).")
-            {
-                Arity = ArgumentArity.ZeroOrOne
-            };
-        var allOption = new Option<bool>(
-            name: "--all",
-            description: "Updates all components with updates available.");
-        AddArgument(componentArgument);
-        AddOption(allOption);
-
-        this.SetHandler(Handle, componentArgument, allOption);
+        this.SetHandler(Handle);
     }
 
-    private async Task Handle(string componentArgument, bool allOption)
+    private async Task Handle()
     {
         try
         {
-            if ((!string.IsNullOrWhiteSpace(componentArgument) && allOption) ||
-                (string.IsNullOrWhiteSpace(componentArgument) && !allOption))
-            {
-                System.Console.Error.WriteLine("ERROR: Either name a component or update --all");
-                Environment.Exit(-1);
-            }
-
             if (Directory.Exists(_manifestService.DotnetInstallLocation))
             {
                 await _manifestService.Initialize();
@@ -70,6 +51,7 @@ public class UpdateCommand : Command
                 if (componentsWithUpdates.Count == 0)
                 {
                     AnsiConsole.WriteLine("There are no updates available.");
+                    return;
                 }
 
                 await AnsiConsole
@@ -115,7 +97,7 @@ public class UpdateCommand : Command
                             }
                         }
 
-                        context.Status("[green]Update complete :check_mark_button:[/]");
+                        AnsiConsole.Write(new Markup("[green]Update complete :check_mark_button:[/]\n"));
                     });
 
                 return;

--- a/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/UpdateCommand.cs
@@ -77,7 +77,7 @@ public class UpdateCommand : Command
                                 }
                                 
                                 toInstall.InstallingPackageChanged += (sender, args) =>
-                                    AnsiConsole.WriteLine($"Installing {args.Package.Name}");
+                                    AnsiConsole.WriteLine($"Installing {args.Package.Name} {args.Component.Version}");
 
                                 context.Status(
                                     $"Updating {toUninstall.Name} from {toUninstall.Version} to {toInstall.Version}...");

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using Dotnet.Installer.Core.Exceptions;
 using Dotnet.Installer.Core.Models.Events;
 using Dotnet.Installer.Core.Services.Contracts;
@@ -65,7 +65,7 @@ public class Component
             // Install component packages
             foreach (var package in Packages)
             {
-                InstallingPackageChanged?.Invoke(this, new InstallingPackageChangedEventArgs(package));
+                InstallingPackageChanged?.Invoke(this, new InstallingPackageChangedEventArgs(package, this));
                 
                 var debUrl = new Uri(BaseUrl, $"{package.Name}_{package.Version}_{architecture}.deb");
 

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Dotnet.Installer.Core.Exceptions;
 using Dotnet.Installer.Core.Models.Events;
 using Dotnet.Installer.Core.Services.Contracts;
@@ -78,8 +78,6 @@ public class Component
 
             // Register the installation of this component in the local manifest file
             await manifestService.Add(this);
-            
-            InstallationFinished?.Invoke(this, new InstallationFinishedEventArgs(Key));
         }
         else
         {
@@ -89,8 +87,15 @@ public class Component
         foreach (var dependency in Dependencies)
         {
             var component = manifestService.Remote.First(c => c.Key == dependency);
+            
+            component.InstallationStarted += InstallationStarted;
+            component.InstallationFinished += InstallationFinished;
+            component.InstallingPackageChanged += InstallingPackageChanged;
+
             await component.Install(fileService, limitsService, manifestService);
         }
+
+        InstallationFinished?.Invoke(this, new InstallationFinishedEventArgs(Key));
     }
 
     public async Task Uninstall(IFileService fileService, IManifestService manifestService)

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -102,10 +102,18 @@ public class Component
     {
         if (Installation is not null)
         {
+            // TODO: Double-check architectures from Architecture enum
+            var architecture = RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64 => "amd64",
+                Architecture.Arm64 => "arm64",
+                _ => throw new UnsupportedArchitectureException(RuntimeInformation.OSArchitecture)
+            };
+
             foreach (var package in Packages)
             {
                 var registrationFileName = Path.Combine(manifestService.SnapConfigurationLocation, 
-                    $"{package.Name}.files");
+                    $"{package.Name}_{package.Version}_{architecture}.files");
 
                 if (!fileService.FileExists(registrationFileName))
                 {

--- a/src/Dotnet.Installer.Core/Models/Events/InstallingPackageChangedEventArgs.cs
+++ b/src/Dotnet.Installer.Core/Models/Events/InstallingPackageChangedEventArgs.cs
@@ -1,6 +1,7 @@
 namespace Dotnet.Installer.Core.Models.Events;
 
-public class InstallingPackageChangedEventArgs(Package package) : EventArgs
+public class InstallingPackageChangedEventArgs(Package package, Component component) : EventArgs
 {
     public Package Package { get; set; } = package;
+    public Component Component { get; set; } = component;
 }

--- a/src/Dotnet.Installer.Core/Services/Implementations/FileService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/FileService.cs
@@ -49,7 +49,7 @@ public class FileService : IFileService
         
         var files = MoveDirectory($"{scratchDirectory}/usr/lib/dotnet", destinationDirectory);
 
-        var packageName = Path.GetFileNameWithoutExtension(debPath).Split('_').First();
+        var packageName = Path.GetFileNameWithoutExtension(debPath);
         await SavePackageContentToFile(files, snapConfigurationDirectory, packageName);
 
         Directory.Delete(scratchDirectory, recursive: true);

--- a/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
@@ -135,7 +135,7 @@ public class ComponentTests
         Assert.NotNull(evt);
         Assert.Equal(component, evt.Sender);
         Assert.Equivalent(new InstallingPackageChangedEventArgs(
-            new Package { Name = "package1", Version = "1.0" }), evt.Arguments);
+            new Package { Name = "package1", Version = "1.0" }, component), evt.Arguments);
     }
     
     [Fact]


### PR DESCRIPTION
- Rename SDK component name from `dotnet-sdk` to `sdk`.
- Allow `install` command to match components by major version only, e.g.
```
$ dotnet installer install sdk 8
$ dotnet installer install sdk 8.0
```
- Add component version to `install` and `update` command feedback.
- Make `update` command always update all components with updates pending.
- Pass down event registrations to dependency components.
- Add version and architecture to package registration filenames.