### PR TITLE
Minor updates and hooks fixes

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -euxo pipefail
 
 # Copy latest host to $SNAP_COMMON
-cp -RLp "$SNAP"/usr/lib/dotnet "$SNAP_COMMON"
+cp --recursive --dereference --preserve=mode,ownership,timestamps "$SNAP"/usr/lib/dotnet "$SNAP_COMMON"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,14 +1,14 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -euxo pipefail
 
 # Create $SNAP_COMMON if doesn't exist
-if [ ! -d "$SNAP_COMMON" ]; then
-    mkdir -p "$SNAP_COMMON"
-fi
+mkdir --parents "$SNAP_COMMON"
 
 # Create .NET installation directory
-mkdir "$SNAP_COMMON"/dotnet
+mkdir --parents "$SNAP_COMMON"/dotnet
 # Create snap configuration directory
-mkdir "$SNAP_COMMON"/snap
+mkdir --parents "$SNAP_COMMON"/snap
 
 # Create an empty local manifest file if it doesn't yet exist.
 if [ ! -e "$SNAP_COMMON"/snap/manifest.json ]; then

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,23 +1,30 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+
+set -euxo pipefail
 
 # Remove remaining systemd-mount units from the system
-if [ -n "$(find /usr/lib/systemd/system/ -type f -name 'var-snap-dotnet-common-dotnet-*.mount')" ]; then
-    systemctl stop var-snap-dotnet-common-dotnet-*.mount
-    systemctl disable var-snap-dotnet-common-dotnet-*.mount
-    rm /usr/lib/systemd/system/var-snap-dotnet-common-dotnet-*.mount
-fi
+find /usr/lib/systemd/system/ -type f -name 'var-snap-dotnet-common-dotnet-*.mount' | while read -r file; do
+    unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
+    systemctl stop "$unit_name"
+    systemctl disable "$unit_name"
+    rm "$file"
+done
 
 # Remove remaining systemd-path units from the system
-if [ -n "$(find /usr/lib/systemd/system/ -type f -name '*-update-watcher.*')" ]; then
-    # shellcheck disable=SC2035
-    systemctl stop *-update-watcher.*
-    # shellcheck disable=SC2035
-    systemctl disable *-update-watcher.*
-    rm /usr/lib/systemd/system/*-update-watcher.*
-fi
+find /usr/lib/systemd/system/ -type f -name 'dotnet-*-update-watcher.*' | while read -r file; do
+    unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
+    systemctl stop "$unit_name"
+    systemctl disable "$unit_name"
+    rm "$file"
+done
 
-# Remove left-over content snaps
-# shellcheck disable=SC2046
-snap remove $(snap list | grep 'dotnet-*' | awk '{print $1}')
-# shellcheck disable=SC2046
-snap remove $(snap list | grep 'aspnetcore-*' | awk '{print $1}')
+systemctl daemon-reload
+
+# Remove left-over dotnet-* content snaps
+for snap in $(snap list | awk '{print $1}' | grep '^dotnet-.*'); do
+    snap remove --purge "$snap"
+done
+# Remove left-over aspnetcore-* content snaps
+for snap in $(snap list | awk '{print $1}' | grep '^aspnetcore-.*'); do
+    snap remove --purge "$snap"
+done

--- a/src/Dotnet.Installer.Console/Commands/EnvironmentCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/EnvironmentCommand.cs
@@ -8,7 +8,7 @@ namespace Dotnet.Installer.Console.Commands;
 public class EnvironmentCommand : Command
 {
     public EnvironmentCommand(IFileService fileService, IManifestService manifestService,
-        ISystemDService systemDService, ILogger logger)
+        ISystemdService systemdService, ILogger logger)
         : base("environment", "Gets information about the current environment.")
     {
         IsHidden = true;
@@ -30,10 +30,10 @@ public class EnvironmentCommand : Command
         infoCommand.SetHandler(HandleInfo);
 
         var mountCommand = new Command("mount", "Mounts all available .NET locations.");
-        mountCommand.SetHandler(() => HandleMount(fileService, manifestService, systemDService, logger));
+        mountCommand.SetHandler(() => HandleMount(fileService, manifestService, systemdService, logger));
 
         var unmountCommand = new Command("unmount", "Unmounts all current .NET bind-mounts.");
-        unmountCommand.SetHandler(() => HandleUnmount(fileService, manifestService, systemDService, logger));
+        unmountCommand.SetHandler(() => HandleUnmount(fileService, manifestService, systemdService, logger));
 
         var placeUnitsCommand = new Command("place-units", "Installs all systemd-mount units in the system.")
         {
@@ -41,7 +41,7 @@ public class EnvironmentCommand : Command
             allOption
         };
         placeUnitsCommand.SetHandler((snapOptionValue, allOptionValue) =>
-            HandlePlaceUnits(snapOptionValue, allOptionValue, fileService, manifestService, systemDService, logger),
+            HandlePlaceUnits(snapOptionValue, allOptionValue, fileService, manifestService, systemdService, logger),
                 snapOption, allOption);
 
         var removeUnitsCommand = new Command("remove-units", "Removes all systemd-mount units from the system.")
@@ -50,7 +50,7 @@ public class EnvironmentCommand : Command
             allOption
         };
         removeUnitsCommand.SetHandler((snapOptionValue, allOptionValue) =>
-            HandleRemoveUnits(snapOptionValue, allOptionValue, fileService, manifestService, systemDService, logger),
+            HandleRemoveUnits(snapOptionValue, allOptionValue, fileService, manifestService, systemdService, logger),
                 snapOption, allOption);
 
         AddCommand(infoCommand);
@@ -71,27 +71,27 @@ public class EnvironmentCommand : Command
     }
 
     private async Task HandleMount(IFileService fileService, IManifestService manifestService,
-        ISystemDService systemDService, ILogger logger)
+        ISystemdService systemdService, ILogger logger)
     {
         await manifestService.Initialize();
         foreach (var installedComponent in manifestService.Local)
         {
-            await installedComponent.Mount(manifestService, fileService, systemDService, logger);
+            await installedComponent.Mount(manifestService, fileService, systemdService, logger);
         }
     }
 
     private async Task HandleUnmount(IFileService fileService, IManifestService manifestService,
-        ISystemDService systemDService, ILogger logger)
+        ISystemdService systemdService, ILogger logger)
     {
         await manifestService.Initialize();
         foreach (var installedComponent in manifestService.Local)
         {
-            await installedComponent.Unmount(fileService, manifestService, systemDService, logger);
+            await installedComponent.Unmount(fileService, manifestService, systemdService, logger);
         }
     }
 
     private async Task HandlePlaceUnits(string snapName, bool allSnaps, IFileService fileService,
-        IManifestService manifestService, ISystemDService systemDService, ILogger logger)
+        IManifestService manifestService, ISystemdService systemdService, ILogger logger)
     {
         try
         {
@@ -108,7 +108,7 @@ public class EnvironmentCommand : Command
 
             foreach (var component in components)
             {
-                await component.PlaceMountUnits(fileService, manifestService, systemDService, logger);
+                await component.PlaceMountUnits(fileService, manifestService, systemdService, logger);
                 logger.LogDebug($"Placed units from snap {component.Key}");
             }
         }
@@ -120,7 +120,7 @@ public class EnvironmentCommand : Command
     }
 
     private async Task HandleRemoveUnits(string snapName, bool allSnaps, IFileService fileService,
-        IManifestService manifestService, ISystemDService systemDService, ILogger logger)
+        IManifestService manifestService, ISystemdService systemdService, ILogger logger)
     {
         try
         {
@@ -137,7 +137,7 @@ public class EnvironmentCommand : Command
 
             foreach (var component in components)
             {
-                await component.RemoveMountUnits(fileService, manifestService, systemDService, logger);
+                await component.RemoveMountUnits(fileService, manifestService, systemdService, logger);
                 logger.LogDebug($"Removed units from snap {component.Key}");
             }
         }

--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -8,21 +8,21 @@ public class InstallCommand : Command
     private readonly IFileService _fileService;
     private readonly IManifestService _manifestService;
     private readonly ISnapService _snapService;
-    private readonly ISystemDService _systemDService;
+    private readonly ISystemdService _systemdService;
     private readonly ILogger _logger;
 
     public InstallCommand(
         IFileService fileService,
         IManifestService manifestService,
         ISnapService snapService,
-        ISystemDService systemDService,
+        ISystemdService systemdService,
         ILogger logger)
         : base("install", "Installs a new .NET component in the system")
     {
         _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         _manifestService = manifestService ?? throw new ArgumentNullException(nameof(manifestService));
         _snapService = snapService ?? throw new ArgumentNullException(nameof(snapService));
-        _systemDService = systemDService ?? throw new ArgumentNullException(nameof(systemDService));
+        _systemdService = systemdService ?? throw new ArgumentNullException(nameof(systemdService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var componentArgument = new Argument<string>(
@@ -63,7 +63,7 @@ public class InstallCommand : Command
                     Environment.Exit(-1);
                 }
 
-                await requestedComponent.Install(_fileService, _manifestService, _snapService, _systemDService,
+                await requestedComponent.Install(_fileService, _manifestService, _snapService, _systemdService,
                     isRootComponent: true, _logger);
 
                 return;

--- a/src/Dotnet.Installer.Console/Commands/RemoveCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/RemoveCommand.cs
@@ -11,21 +11,21 @@ public class RemoveCommand : Command
     private readonly IFileService _fileService;
     private readonly IManifestService _manifestService;
     private readonly ISnapService _snapService;
-    private readonly ISystemDService _systemDService;
+    private readonly ISystemdService _systemdService;
     private readonly ILogger _logger;
 
     public RemoveCommand(
         IFileService fileService,
         IManifestService manifestService,
         ISnapService snapService,
-        ISystemDService systemDService,
+        ISystemdService systemdService,
         ILogger logger)
         : base("remove", "Removes an installed .NET component from the system")
     {
         _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         _manifestService = manifestService ?? throw new ArgumentNullException(nameof(manifestService));
         _snapService = snapService ?? throw new ArgumentNullException(nameof(snapService));
-        _systemDService = systemDService ?? throw new ArgumentNullException(nameof(systemDService));
+        _systemdService = systemdService ?? throw new ArgumentNullException(nameof(systemdService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         var componentArgument = new Argument<string>(
@@ -97,7 +97,7 @@ public class RemoveCommand : Command
                 }
             }
 
-            await requestedComponent.Uninstall(_fileService, _manifestService, _snapService, _systemDService, _logger);
+            await requestedComponent.Uninstall(_fileService, _manifestService, _snapService, _systemdService, _logger);
         }
         catch (ApplicationException ex)
         {

--- a/src/Dotnet.Installer.Console/Dotnet.Installer.Console.csproj
+++ b/src/Dotnet.Installer.Console/Dotnet.Installer.Console.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/Dotnet.Installer.Console/Program.cs
+++ b/src/Dotnet.Installer.Console/Program.cs
@@ -29,7 +29,7 @@ class Program
         var fileService = new FileService();
         var manifestService = new ManifestService();
         var snapService = new SnapService();
-        var systemDService = new SystemDService();
+        var systemDService = new SystemdService();
         var logger = new Logger();
 
         var rootCommand = new RootCommand(".NET Installer command-line tool")

--- a/src/Dotnet.Installer.Core/Services/Contracts/ISystemdService.cs
+++ b/src/Dotnet.Installer.Core/Services/Contracts/ISystemdService.cs
@@ -2,7 +2,7 @@ using Dotnet.Installer.Core.Types;
 
 namespace Dotnet.Installer.Core.Services.Contracts;
 
-public interface ISystemDService
+public interface ISystemdService
 {
     Task<InvocationResult> DaemonReload();
     Task<InvocationResult> EnableUnit(string unit);

--- a/src/Dotnet.Installer.Core/Services/Implementations/SystemdService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/SystemdService.cs
@@ -3,7 +3,7 @@ using Dotnet.Installer.Core.Types;
 
 namespace Dotnet.Installer.Core.Services.Implementations;
 
-public class SystemDService : ISystemDService
+public class SystemdService : ISystemdService
 {
     public async Task<InvocationResult> DaemonReload()
     {

--- a/src/Dotnet.Installer.Core/Services/Implementations/SystemdService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/SystemdService.cs
@@ -5,33 +5,39 @@ namespace Dotnet.Installer.Core.Services.Implementations;
 
 public class SystemdService : ISystemdService
 {
+    private readonly Terminal.InvocationOptions _globalSystemdOptions = new()
+    {
+        RedirectStandardError = true,
+        RedirectStandardOutput = true,
+    };
+    
     public async Task<InvocationResult> DaemonReload()
     {
-        var result = await Terminal.Invoke("systemctl", "daemon-reload");
+        var result = await Terminal.Invoke("systemctl", _globalSystemdOptions, "daemon-reload");
         return new InvocationResult(result == 0, string.Empty, string.Empty);
     }
 
     public async Task<InvocationResult> EnableUnit(string unit)
     {
-        var result = await Terminal.Invoke("systemctl", "enable", unit);
+        var result = await Terminal.Invoke("systemctl", _globalSystemdOptions, "enable", unit);
         return new InvocationResult(result == 0, string.Empty, string.Empty);
     }
 
     public async Task<InvocationResult> DisableUnit(string unit)
     {
-        var result = await Terminal.Invoke("systemctl", "disable", unit);
+        var result = await Terminal.Invoke("systemctl", _globalSystemdOptions, "disable", unit);
         return new InvocationResult(result == 0, string.Empty, string.Empty);
     }
 
     public async Task<InvocationResult> StartUnit(string unit)
     {
-        var result = await Terminal.Invoke("systemctl", "start", unit);
+        var result = await Terminal.Invoke("systemctl", _globalSystemdOptions, "start", unit);
         return new InvocationResult(result == 0, string.Empty, string.Empty);
     }
 
     public async Task<InvocationResult> StopUnit(string unit)
     {
-        var result = await Terminal.Invoke("systemctl", "stop", unit);
+        var result = await Terminal.Invoke("systemctl", _globalSystemdOptions, "stop", unit);
         return new InvocationResult(result == 0, string.Empty, string.Empty);
     }
 }

--- a/src/Dotnet.Installer.Core/Types/Terminal.cs
+++ b/src/Dotnet.Installer.Core/Types/Terminal.cs
@@ -6,20 +6,36 @@ public static class Terminal
 {
     public static async Task<int> Invoke(string program, params string[] arguments)
     {
+        return await Invoke(program, options: null, arguments);
+    }
+
+    public static async Task<int> Invoke(string program, InvocationOptions? options = default,
+        params string[] arguments)
+    {
+        options ??= InvocationOptions.Default;
+
         var process = new Process();
 
         process.StartInfo.FileName = program;
-        
+
         foreach (var argument in arguments)
             process.StartInfo.ArgumentList.Add(argument);
-        
+
         process.StartInfo.CreateNoWindow = true;
-        process.StartInfo.RedirectStandardOutput = false;
-        process.StartInfo.RedirectStandardError = false;
+        process.StartInfo.RedirectStandardOutput = options.RedirectStandardOutput;
+        process.StartInfo.RedirectStandardError = options.RedirectStandardError;
 
         process.Start();
         await process.WaitForExitAsync();
 
         return process.ExitCode;
+    }
+
+    public class InvocationOptions
+    {
+        public static InvocationOptions Default => new();
+
+        public bool RedirectStandardOutput { get; set; } = false;
+        public bool RedirectStandardError { get; set; } = false;
     }
 }

--- a/tests/Dotnet.Installer.Core.Tests/Dotnet.Installer.Core.Tests.csproj
+++ b/tests/Dotnet.Installer.Core.Tests/Dotnet.Installer.Core.Tests.csproj
@@ -10,14 +10,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-        <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
@@ -26,7 +26,7 @@ public class ComponentTests
         var fileService = new Mock<IFileService>();
         var manifestService = new Mock<IManifestService>();
         var snapService = new Mock<ISnapService>();
-        var systemDService = new Mock<ISystemDService>();
+        var systemDService = new Mock<ISystemdService>();
 
         snapService.Setup(s => s.Install(It.IsAny<string>(), CancellationToken.None))
             .ReturnsAsync(new InvocationResult(
@@ -70,7 +70,7 @@ public class ComponentTests
         var fileService = new Mock<IFileService>();
         var manifestService = new Mock<IManifestService>();
         var snapService = new Mock<ISnapService>();
-        var systemDService = new Mock<ISystemDService>();
+        var systemDService = new Mock<ISystemdService>();
 
         snapService.Setup(s => s.Install(It.IsAny<string>(), CancellationToken.None))
             .ReturnsAsync(new InvocationResult(
@@ -135,7 +135,7 @@ public class ComponentTests
         var fileService = new Mock<IFileService>();
         var manifestService = new Mock<IManifestService>();
         var snapService = new Mock<ISnapService>();
-        var systemDService = new Mock<ISystemDService>();
+        var systemDService = new Mock<ISystemdService>();
 
         manifestService.Setup(s => s.Remote).Returns([component1, component2, component3]);
         manifestService.Setup(e => e.Add(
@@ -189,7 +189,7 @@ public class ComponentTests
         var fileService = new Mock<IFileService>();
         var manifestService = new Mock<IManifestService>();
         var snapService = new Mock<ISnapService>();
-        var systemDService = new Mock<ISystemDService>();
+        var systemDService = new Mock<ISystemdService>();
 
         fileService.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
         manifestService.Setup(m => m.DotnetInstallLocation).Returns("dotnet_install_path");


### PR DESCRIPTION
This PR:

- Renames every systemd-related service to `Systemd*`, instead of `SystemD*`.
- Updates NuGet packages to their latest versions.
- Fixes `remove` snap hook, which now fully works, and irons out other minor details of other hooks, such as usage of full name parameters and proper shebang.