### PR TITLE
Installer enhancements for .NET 9

### DIFF
--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -47,7 +47,7 @@ public class InstallCommand : Command
         {
             if (Directory.Exists(_manifestService.DotnetInstallLocation))
             {
-                await _manifestService.Initialize(includeArchive: true);
+                await _manifestService.Initialize(includeUnsupported: true);
 
                 var requestedComponent = version switch
                 {

--- a/src/Dotnet.Installer.Console/Commands/ListCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/ListCommand.cs
@@ -19,14 +19,23 @@ public class ListCommand : Command
         _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         _manifestService = manifestService ?? throw new ArgumentNullException(nameof(manifestService));
 
-        this.SetHandler(Handle);
+        var includeUnsupportedOption = new Option<bool>(
+            name: "--all",
+            description: "Include unsupported .NET components in the list output.")
+            {
+                IsRequired = false
+            };
+
+        AddOption(includeUnsupportedOption);
+
+        this.SetHandler(Handle, includeUnsupportedOption);
     }
 
-    private async Task Handle()
+    private async Task Handle(bool includeUnsupported)
     {
         try
         {
-            await _manifestService.Initialize();
+            await _manifestService.Initialize(includeUnsupported);
 
             var table = new Table();
 

--- a/src/Dotnet.Installer.Console/Commands/ListCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/ListCommand.cs
@@ -60,12 +60,9 @@ public class ListCommand : Command
 
                 var endOfLife = majorVersionGroup.First().EndOfLife;
                 var isEndOfLife = endOfLife < DateTime.Now;
+                var isLts = majorVersionGroup.First().IsLts;
 
-                var dotnetVersionStringBuilder = new StringBuilder();
-                dotnetVersionStringBuilder.Append($".NET {majorVersionGroup.Key}");
-                if (majorVersionGroup.First().IsLts)
-                    dotnetVersionStringBuilder.Append(" LTS");
-
+                var dotnetVersionString = $".NET {majorVersionGroup.Key}{(isLts ? " LTS" : "")}";
                 var dotNetRuntimeStatus = ComponentStatus(
                     Constants.DotnetRuntimeComponentName,
                     majorVersionGroup.Key,
@@ -77,18 +74,14 @@ public class ListCommand : Command
                 var sdkStatus = ComponentStatus(Constants.SdkComponentName,
                     majorVersionGroup.Key,
                     isEndOfLife);
-
-                var eolStringBuilder = new StringBuilder();
-                eolStringBuilder.Append(isEndOfLife ? "[bold red]" : "[bold green]");
-                eolStringBuilder.Append(endOfLife.ToShortDateString());
-                eolStringBuilder.Append("[/]");
+                var eolString = $"[bold {(isEndOfLife ? "red" : "green")}]{endOfLife:d}[/]";
 
                 table.AddRow(
-                    dotnetVersionStringBuilder.ToString(),
+                    dotnetVersionString,
                     dotNetRuntimeStatus,
                     aspNetCoreRuntimeStatus,
                     sdkStatus,
-                    eolStringBuilder.ToString());
+                    eolString);
 
                 continue;
 

--- a/src/Dotnet.Installer.Console/Commands/ListCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/ListCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.Text;
 using Dotnet.Installer.Core.Models;
 using Dotnet.Installer.Core.Services.Contracts;
 using Dotnet.Installer.Core.Types;
@@ -33,6 +34,7 @@ public class ListCommand : Command
             table.AddColumn(new TableColumn(".NET Runtime"));
             table.AddColumn(new TableColumn("ASP.NET Core Runtime"));
             table.AddColumn(new TableColumn("SDK"));
+            table.AddColumn(new TableColumn("End of Life"));
 
             foreach (var majorVersionGroup in _manifestService.Merged
                          .GroupBy(c => c.MajorVersion)
@@ -51,7 +53,20 @@ public class ListCommand : Command
                 var aspNetCoreRuntimeStatus = ComponentStatus(Constants.AspnetCoreRuntimeComponentName, majorVersionGroup.Key);
                 var sdkStatus = ComponentStatus(Constants.SdkComponentName, majorVersionGroup.Key);
 
-                table.AddRow($".NET {majorVersionGroup.Key.ToString()}", dotNetRuntimeStatus, aspNetCoreRuntimeStatus, sdkStatus);
+                var endOfLife = majorVersionGroup.First().EndOfLife;
+                var isEndOfLife = endOfLife < DateTime.Now;
+
+                var eolStringBuilder = new StringBuilder();
+                eolStringBuilder.Append(isEndOfLife ? "[bold red]" : "[bold green]");
+                eolStringBuilder.Append(endOfLife.ToShortDateString());
+                eolStringBuilder.Append("[/]");
+
+                table.AddRow($".NET {majorVersionGroup.Key.ToString()}",
+                    dotNetRuntimeStatus,
+                    aspNetCoreRuntimeStatus,
+                    sdkStatus,
+                    eolStringBuilder.ToString());
+
                 continue;
 
                 string ComponentStatus(string key, int majorVersion)

--- a/src/Dotnet.Installer.Console/Commands/ListCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/ListCommand.cs
@@ -94,23 +94,19 @@ public class ListCommand : Command
 
                 string ComponentStatus(string key, int majorVersion, bool isEol)
                 {
-                    string status;
-                    var available = _manifestService.Remote.Any(c => c.Name == key && c.MajorVersion == majorVersion);
-
                     if (components.TryGetValue(key, out var component))
                     {
-                        status = $"[bold green]Installed [[{component.Version}]][/]";
-                    }
-                    else
-                    {
-                        status = available
-                            ? isEol
-                                ? "Available"
-                                : "[bold blue]Available[/]"
-                            : "[bold grey]-[/]";
+                        return $"[bold green]Installed [[{component.Version}]][/]";
                     }
 
-                    return status;
+                    var available = _manifestService.Remote.Any(c => c.Name == key && c.MajorVersion == majorVersion);
+
+                    if (!available)
+                    {
+                        return "[grey]-[/]";
+                    }
+
+                    return isEol ? "[grey]Available[/]" : "[bold blue]Available[/]";
                 }
             }
 

--- a/src/Dotnet.Installer.Core/Services/Contracts/IManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Contracts/IManifestService.cs
@@ -11,7 +11,7 @@ public interface IManifestService
     IEnumerable<Component> Remote { get; }
     IEnumerable<Component> Merged { get; }
 
-    Task Initialize(bool includeArchive = false, CancellationToken cancellationToken = default);
+    Task Initialize(bool includeUnsupported = false, CancellationToken cancellationToken = default);
     Task Add(Component component, bool isRootComponent, CancellationToken cancellationToken = default);
     Task Remove(Component component, CancellationToken cancellationToken = default);
     Component? MatchVersion(string component, string version);

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
@@ -32,7 +32,7 @@ public partial class ManifestService
         };
 
         if (includeUnsupported)
-            filesToRead.Add(Path.Join("/", "snap", "dotnet-manifest", "current", "archive.json"));
+            filesToRead.Add(Path.Join("/", "snap", "dotnet-manifest", "current", "unsupported.json"));
 
         var components = new List<Component>();
         foreach (var contentStream in filesToRead.Select(File.OpenRead))

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
@@ -54,7 +54,7 @@ public partial class ManifestService
     private async Task Refresh(CancellationToken cancellationToken = default)
     {
         _local = await LoadLocal(cancellationToken);
-        _remote = await LoadRemote(_includeArchive, cancellationToken);
+        _remote = await LoadRemote(_includeUnsupported, cancellationToken);
         _merged = Merge(_remote, _local);
     }
 

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.Private.cs
@@ -32,7 +32,9 @@ public partial class ManifestService
         };
 
         if (includeUnsupported)
+        {
             filesToRead.Add(Path.Join("/", "snap", "dotnet-manifest", "current", "unsupported.json"));
+        }
 
         var components = new List<Component>();
         foreach (var contentStream in filesToRead.Select(File.OpenRead))

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
@@ -14,7 +14,7 @@ public partial class ManifestService : IManifestService
     private List<Component> _local = [];
     private List<Component> _remote = [];
     private List<Component> _merged = [];
-    private bool _includeArchive = false;
+    private bool _includeUnsupported = false;
 
     public string SnapConfigurationLocation => SnapConfigPath;
     public string DotnetInstallLocation =>
@@ -49,9 +49,9 @@ public partial class ManifestService : IManifestService
         private set => _merged = value.ToList();
     }
 
-    public Task Initialize(bool includeArchive = false, CancellationToken cancellationToken = default)
+    public Task Initialize(bool includeUnsupported = false, CancellationToken cancellationToken = default)
     {
-        _includeArchive = includeArchive;
+        _includeUnsupported = includeUnsupported;
         return Refresh(cancellationToken);
     }
 


### PR DESCRIPTION
This PR includes the following enhancements for the .NET Installer:

- Added an "End of Life" column to `dotnet installer list` output.
- Created the `--all` flag to list both supported and unsupported releases in `dotnet installer list`.
- Added "LTS" indicator to `dotnet installer list`.
- Added support for the `unsupported.json` file from the _dotnet-manifest_ snap.

Output example:
```
┌────────────┬────────────────────┬──────────────────────┬───────────┬─────────────┐
│ Version    │ .NET Runtime       │ ASP.NET Core Runtime │ SDK       │ End of Life │
├────────────┼────────────────────┼──────────────────────┼───────────┼─────────────┤
│ .NET 6 LTS │ Installed [6.0.36] │ Available            │ Available │ 11/12/2024  │
│ .NET 8 LTS │ Available          │ Available            │ Available │ 11/10/2026  │
│ .NET 9     │ Available          │ Available            │ Available │ 5/12/2026   │
└────────────┴────────────────────┴──────────────────────┴───────────┴─────────────┘
```
**Note:** Unsupported releases are shown in a different color in the output.