### PR TITLE
Change first run to install latest .NET SDK LTS version

### DIFF
--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -54,6 +54,9 @@ public class InstallCommand : Command
                     "latest" => _manifestService.Remote
                         .Where(c => c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase))
                         .MaxBy(c => c.MajorVersion),
+                    "lts" => _manifestService.Remote
+                        .Where(c => c.IsLts && c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase))
+                        .MaxBy(c => c.MajorVersion),
                     _ => _manifestService.MatchVersion(component, version)
                 };
 

--- a/src/Dotnet.Installer.Console/Scripts/dotnet-launcher.sh
+++ b/src/Dotnet.Installer.Console/Scripts/dotnet-launcher.sh
@@ -55,7 +55,7 @@ else
         echo "Looks like you don't yet have a .NET SDK or Runtime installed."
         echo "I am downloading and installing the latest SDK for you to use. It should only be a few moments."
 
-        command_to_execute=("$SNAP/Dotnet.Installer.Console" "install" "sdk" "latest")
+        command_to_execute=("$SNAP/Dotnet.Installer.Console" "install" "sdk" "lts")
 
         if ! run_elevated "0" "${command_to_execute[@]}"; then
             echo "Could not install the latest .NET SDK. Please check your credentials or run this command with sudo."

--- a/src/Dotnet.Installer.Console/Scripts/dotnet-launcher.sh
+++ b/src/Dotnet.Installer.Console/Scripts/dotnet-launcher.sh
@@ -49,9 +49,8 @@ if [[ $# -gt 0 && $1 = "installer" ]]; then
 else
     # Check for installed .NET components
     manifest_path="$SNAP_COMMON/snap/manifest.json"
-    manifest_data=$(< "$manifest_path")
 
-    if [[ $(echo "$manifest_data" | "$SNAP"/usr/bin/jq 'length') -eq 0 ]]; then
+    if [[ $("$SNAP"/usr/bin/jq 'length' "$manifest_path") -eq 0 ]]; then
         echo "Looks like you don't yet have a .NET SDK or Runtime installed."
         echo "I am downloading and installing the latest SDK for you to use. It should only be a few moments."
 


### PR DESCRIPTION
The first run experience of running `dotnet` should be to have the installer automatically install the latest LTS SDK instead of the very latest SDK, which might be an STS release.

This PR implements that feature by adding an `lts` option to the `install` command, which maps to the latest LTS, and changing the launcher accordingly.