### PR TITLE
Remove root components from .NET Installer

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,5 +2,47 @@
 
 set -euxo pipefail
 
+#####################################
+# Transition to non-root components #
+#####################################
+
+# Remove remaining systemd-mount units from the system
+find /usr/lib/systemd/system/ -type f -name 'var-snap-dotnet-common-dotnet-*.mount' | while read -r file; do
+    unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
+    systemctl stop "$unit_name"
+    systemctl disable "$unit_name"
+    rm "$file"
+done
+
+# Remove remaining systemd-path units from the system
+find /usr/lib/systemd/system/ -type f -name 'dotnet-*-update-watcher.*' | while read -r file; do
+    unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
+    systemctl stop "$unit_name"
+    systemctl disable "$unit_name"
+    rm "$file"
+done
+
+find /usr/lib/systemd/system/ -type f -name 'aspnetcore-*-update-watcher.*' | while read -r file; do
+    unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
+    systemctl stop "$unit_name"
+    systemctl disable "$unit_name"
+    rm "$file"
+done
+
+systemctl daemon-reload
+
+rm -rf "$SNAP_COMMON"/snap
+rm -rf "$SNAP_COMMON"/dotnet
+
+# Create .NET installation directory
+mkdir --parents "$SNAP_COMMON"/dotnet
+# Create snap configuration directory
+mkdir --parents "$SNAP_COMMON"/snap
+
+# Create an empty local manifest file if it doesn't yet exist.
+if [ ! -e "$SNAP_COMMON"/snap/manifest.json ]; then
+    echo "[ ]" > "$SNAP_COMMON"/snap/manifest.json
+fi
+
 # Copy latest host to $SNAP_COMMON
 cp --recursive --dereference --preserve=mode,ownership,timestamps "$SNAP"/usr/lib/dotnet "$SNAP_COMMON"

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -24,6 +24,13 @@ find /usr/lib/systemd/system/ -type f -name 'dotnet-*-update-watcher.*' | while 
     rm "$file"
 done
 
+find /usr/lib/systemd/system/ -type f -name 'aspnetcore-*-update-watcher.*' | while read -r file; do
+    unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
+    systemctl stop "$unit_name"
+    systemctl disable "$unit_name"
+    rm "$file"
+done
+
 systemctl daemon-reload
 
 ##################################

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -2,7 +2,10 @@
 
 set -euxo pipefail
 
-# Remove remaining systemd-mount units from the system
+########################################################
+# Remove remaining systemd-mount units from the system #
+########################################################
+
 find /usr/lib/systemd/system/ -type f -name 'var-snap-dotnet-common-dotnet-*.mount' | while read -r file; do
     unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
     systemctl stop "$unit_name"
@@ -10,7 +13,10 @@ find /usr/lib/systemd/system/ -type f -name 'var-snap-dotnet-common-dotnet-*.mou
     rm "$file"
 done
 
-# Remove remaining systemd-path units from the system
+#######################################################
+# Remove remaining systemd-path units from the system #
+#######################################################
+
 find /usr/lib/systemd/system/ -type f -name 'dotnet-*-update-watcher.*' | while read -r file; do
     unit_name=$(echo "$file" | rev | cut -d / -f 1 | rev)
     systemctl stop "$unit_name"
@@ -20,7 +26,10 @@ done
 
 systemctl daemon-reload
 
-# Remove left-over dotnet-* content snaps
+##################################
+# Remove left-over content snaps #
+##################################
+
 for snap in $(snap list | awk '{print $1}' | grep '^dotnet-.*'); do
     snap remove --purge "$snap"
 done

--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -66,8 +66,12 @@ public class InstallCommand : Command
                     Environment.Exit(-1);
                 }
 
-                await requestedComponent.Install(_fileService, _manifestService, _snapService, _systemdService,
-                    isRootComponent: true, _logger);
+                await requestedComponent.Install(
+                    _fileService,
+                    _manifestService,
+                    _snapService,
+                    _systemdService,
+                    _logger);
 
                 return;
             }

--- a/src/Dotnet.Installer.Console/Commands/RemoveCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/RemoveCommand.cs
@@ -98,6 +98,10 @@ public class RemoveCommand : Command
             }
 
             await requestedComponent.Uninstall(_fileService, _manifestService, _snapService, _systemdService, _logger);
+            foreach (var reverseDependency in reverseDependencies)
+            {
+                await reverseDependency.Uninstall(_fileService, _manifestService, _snapService, _systemdService, _logger);
+            }
         }
         catch (ApplicationException ex)
         {

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -35,7 +35,7 @@ public class Component
         // Install content snap on the machine
         if (!snapService.IsSnapInstalled(Key))
         {
-            var result = await snapService.Install(Key, edge: true); // TODO: Remove 'edge' flag from here
+            var result = await snapService.Install(Key);
             if (!result.IsSuccess) throw new ApplicationException(result.StandardError);
         }
 

--- a/src/Dotnet.Installer.Core/Models/Installation.cs
+++ b/src/Dotnet.Installer.Core/Models/Installation.cs
@@ -3,5 +3,4 @@
 public class Installation
 {
     public DateTimeOffset InstalledAt { get; set; }
-    public bool IsRootComponent { get; set; }
 }

--- a/src/Dotnet.Installer.Core/Services/Contracts/IManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Contracts/IManifestService.cs
@@ -12,7 +12,7 @@ public interface IManifestService
     IEnumerable<Component> Merged { get; }
 
     Task Initialize(bool includeUnsupported = false, CancellationToken cancellationToken = default);
-    Task Add(Component component, bool isRootComponent, CancellationToken cancellationToken = default);
+    Task Add(Component component, CancellationToken cancellationToken = default);
     Task Remove(Component component, CancellationToken cancellationToken = default);
     Component? MatchVersion(string component, string version);
 }

--- a/src/Dotnet.Installer.Core/Services/Contracts/ISnapService.cs
+++ b/src/Dotnet.Installer.Core/Services/Contracts/ISnapService.cs
@@ -6,7 +6,7 @@ namespace Dotnet.Installer.Core.Services.Contracts;
 public interface ISnapService : IDisposable
 {
     bool IsSnapInstalled(string name, CancellationToken cancellationToken = default);
-    Task<Terminal.InvocationResult> Install(string name, CancellationToken cancellationToken = default);
+    Task<Terminal.InvocationResult> Install(string name, bool edge = false, CancellationToken cancellationToken = default);
     Task<Terminal.InvocationResult> Remove(string name, bool purge = false, CancellationToken cancellationToken = default);
     Task<IImmutableList<SnapInfo>> GetInstalledSnaps(CancellationToken cancellationToken = default);
     Task<SnapInfo?> GetInstalledSnap(string name, CancellationToken cancellationToken = default);

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
@@ -55,12 +55,11 @@ public partial class ManifestService : IManifestService
         return Refresh(cancellationToken);
     }
 
-    public async Task Add(Component component, bool isRootComponent, CancellationToken cancellationToken = default)
+    public async Task Add(Component component, CancellationToken cancellationToken = default)
     {
         component.Installation = new Installation
         {
-            InstalledAt = DateTimeOffset.UtcNow,
-            IsRootComponent = isRootComponent
+            InstalledAt = DateTimeOffset.UtcNow
         };
         _local.Add(component);
         await Save(cancellationToken);

--- a/src/Dotnet.Installer.Core/Services/Implementations/SnapService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/SnapService.cs
@@ -11,9 +11,17 @@ public partial class SnapService : ISnapService
         return Directory.Exists(Path.Combine("/", "snap", name));
     }
 
-    public Task<Terminal.InvocationResult> Install(string name, CancellationToken cancellationToken = default)
+    public Task<Terminal.InvocationResult> Install(string name, bool edge = false, CancellationToken cancellationToken = default)
     {
-        return Terminal.Invoke("snap", "install", name);
+        var arguments = new List<string>
+        {
+            "install"
+        };
+
+        if (edge) arguments.Add("--edge");
+        arguments.Add(name);
+
+        return Terminal.Invoke("snap", arguments.ToArray());
     }
 
     public Task<Terminal.InvocationResult> Remove(string name, bool purge = false, CancellationToken cancellationToken = default)

--- a/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
@@ -28,7 +28,7 @@ public class ComponentTests
         var snapService = new Mock<ISnapService>();
         var systemDService = new Mock<ISystemdService>();
 
-        snapService.Setup(s => s.Install(It.IsAny<string>(), CancellationToken.None))
+        snapService.Setup(s => s.Install(It.IsAny<string>(), It.IsAny<bool>(), CancellationToken.None))
             .ReturnsAsync(new Terminal.InvocationResult(
                 exitCode: 0, standardOutput: string.Empty, standardError: string.Empty));
 
@@ -44,7 +44,7 @@ public class ComponentTests
             h => component.InstallationStarted += h,
             h => component.InstallationStarted -= h,
             () => component.Install(fileService.Object, manifestService.Object, snapService.Object,
-                systemDService.Object, isRootComponent: true));
+                systemDService.Object));
 
         // Assert
         Assert.NotNull(evt);
@@ -72,7 +72,7 @@ public class ComponentTests
         var snapService = new Mock<ISnapService>();
         var systemDService = new Mock<ISystemdService>();
 
-        snapService.Setup(s => s.Install(It.IsAny<string>(), CancellationToken.None))
+        snapService.Setup(s => s.Install(It.IsAny<string>(), It.IsAny<bool>(), CancellationToken.None))
             .ReturnsAsync(new Terminal.InvocationResult(
                 exitCode: 0, standardOutput: string.Empty, standardError: string.Empty));
 
@@ -88,7 +88,7 @@ public class ComponentTests
             h => component.InstallationFinished += h,
             h => component.InstallationFinished -= h,
             () => component.Install(fileService.Object, manifestService.Object, snapService.Object,
-                systemDService.Object, isRootComponent: true));
+                systemDService.Object));
 
         // Assert
         Assert.NotNull(evt);
@@ -139,13 +139,13 @@ public class ComponentTests
 
         manifestService.Setup(s => s.Remote).Returns([component1, component2, component3]);
         manifestService.Setup(e => e.Add(
-                It.IsAny<Component>(), It.IsAny<bool>(), CancellationToken.None))
-            .Callback((Component c, bool isRootComponent, CancellationToken cancellationToken) =>
+                It.IsAny<Component>(), CancellationToken.None))
+            .Callback((Component c, CancellationToken cancellationToken) =>
             {
                 installedComponents.Add(c.Key);
             });
 
-        snapService.Setup(s => s.Install(It.IsAny<string>(), CancellationToken.None))
+        snapService.Setup(s => s.Install(It.IsAny<string>(), It.IsAny<bool>(), CancellationToken.None))
             .ReturnsAsync(new Terminal.InvocationResult(
                 exitCode: 0, standardOutput: string.Empty, standardError: string.Empty));
 
@@ -157,8 +157,7 @@ public class ComponentTests
             .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
 
         // Act
-        await component1.Install(fileService.Object, manifestService.Object, snapService.Object, systemDService.Object,
-            isRootComponent: true);
+        await component1.Install(fileService.Object, manifestService.Object, snapService.Object, systemDService.Object);
 
         // Assert
         Assert.True(installedComponents.Count == 3);
@@ -181,8 +180,7 @@ public class ComponentTests
             EndOfLife = DateTime.Now,
             Installation = new Installation
             {
-                InstalledAt = new DateTimeOffset(2024, 3, 19, 19, 3, 0, TimeSpan.FromHours(-3)),
-                IsRootComponent = true
+                InstalledAt = new DateTimeOffset(2024, 3, 19, 19, 3, 0, TimeSpan.FromHours(-3))
             }
         };
 


### PR DESCRIPTION
This PR removes the concept of "root components" from the .NET Installer. Effectively, this means that every installed .NET component will also install its dependencies' content snaps as well, even if the component itself already includes the binaries of its dependencies within itself.

This will make it easier to track installed components, reduce duplication of mount units within the content snaps themselves, and make the install/uninstall experience more natural.