### PR TITLE
Install `dotnet-manifest` during `install` hook

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,6 +2,11 @@
 
 set -euxo pipefail
 
+# Install dotnet-manifest snap if it does not exist
+if [ ! -d "/snap/dotnet-manifest" ]; then
+    /usr/bin/snap install dotnet-manifest
+fi
+
 # Create $SNAP_COMMON if doesn't exist
 mkdir --parents "$SNAP_COMMON"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,13 +26,6 @@ architectures:
   - build-on: [arm64]
     build-for: [arm64]
 
-plugs:
-  dotnet-manifest:
-    interface: content
-    target: $SNAP
-    content: dotnet-manifest
-    default-provider: dotnet-manifest
-
 parts:
   pre-reqs:
     plugin: nil


### PR DESCRIPTION
The latest submission of the `dotnet` snap to the Snap Store failed with `confinement 'classic' not allowed with plugs/slots`. This was caused because the `dotnet-manifest` snap was listed as a default provider for the manifest plug, which was used solely as a mechanism to install this snap automatically along with the `dotnet` snap. However, slots/plugs are not allowed with classic snaps.

For this reason, the `dotnet-manifest` snap will be installed during the `install` hook of the `dotnet` snap.

See: https://github.com/canonical/dotnet-manifest/pull/7