### PR TITLE
Version parsing: check if 'minor' is an empty string

### DIFF
--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
@@ -115,7 +115,7 @@ public partial class ManifestService : IManifestService
         var parsedVersion = DotnetVersionPattern.Match(version);
 
         if (!parsedVersion.Success) return null;
-        if (parsedVersion.Groups["minor"].Success)
+        if (parsedVersion.Groups["minor"].Success
             && int.Parse(parsedVersion.Groups["minor"].Value) != 0)
         {
             return null;

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
@@ -115,8 +115,7 @@ public partial class ManifestService : IManifestService
         var parsedVersion = DotnetVersionPattern.Match(version);
 
         if (!parsedVersion.Success) return null;
-        if (parsedVersion.Groups.ContainsKey("minor")
-            && !string.IsNullOrWhiteSpace(parsedVersion.Groups["minor"].Value)
+        if (parsedVersion.Groups["minor"].Success)
             && int.Parse(parsedVersion.Groups["minor"].Value) != 0)
         {
             return null;

--- a/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/ManifestService.cs
@@ -7,7 +7,7 @@ namespace Dotnet.Installer.Core.Services.Implementations;
 
 public partial class ManifestService : IManifestService
 {
-    private static Regex DotnetVersionPattern = new (
+    private static readonly Regex DotnetVersionPattern = new (
         pattern: @"\A(?'major'\d+)(?:\.(?'minor'\d+))?\z");
 
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
@@ -115,15 +115,16 @@ public partial class ManifestService : IManifestService
         var parsedVersion = DotnetVersionPattern.Match(version);
 
         if (!parsedVersion.Success) return null;
-        if (parsedVersion.Groups.ContainsKey("minor") 
+        if (parsedVersion.Groups.ContainsKey("minor")
+            && !string.IsNullOrWhiteSpace(parsedVersion.Groups["minor"].Value)
             && int.Parse(parsedVersion.Groups["minor"].Value) != 0)
         {
             return null;
         }
 
-        int majorVersion = int.Parse(parsedVersion.Groups["major"].Value);
+        var majorVersion = int.Parse(parsedVersion.Groups["major"].Value);
 
-        return components.Where(c => 
+        return components.Where(c =>
                 c.MajorVersion == majorVersion &&
                 c.Name.Equals(component, StringComparison.CurrentCultureIgnoreCase))
             .MaxBy(c => c.MajorVersion);


### PR DESCRIPTION
When the user provides a .NET version with its major version only, e.g. `dotnet-installer install sdk 8`, the matching algorithm throws an exception because `int.Parse` was trying to parse an empty string -- the 'minor' group here is empty.

This fixes the problem by checking whether the 'minor' group is null, empty, or white-space before attempting `int.Parse`.

Closes #26 