### PR TITLE
feat: adding transactional install rollback

### DIFF
--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -44,40 +44,60 @@ public class Component
 
         InstallationStarted?.Invoke(this, new InstallationStartedEventArgs(Key));
 
-        // Install content snap on the machine
-        if (!snapService.IsSnapInstalled(Key))
+        // Install dependencies first. If a dependency fails, it will roll itself back
+        // and throw, preventing this component from being registered as installed.
+        foreach (var dependencyKey in Dependencies)
         {
-            // Gather highest channel available
-            var snapInfo = await snapService.FindSnap(Key);
-
-            var channel = snapInfo?.Channel switch
-            {
-                "candidate" => SnapChannel.Candidate,
-                "beta" => SnapChannel.Beta,
-                "edge" => SnapChannel.Edge,
-                _ => SnapChannel.Stable
-            };
-
-            var result = await snapService.Install(Key, channel);
-            if (!result.IsSuccess) throw new ApplicationException(result.StandardError);
+            var dependency = manifestService.Remote.FirstOrDefault(c => c.Key == dependencyKey) ?? throw new ApplicationException(
+                    $"Dependency {dependencyKey} for component {Key} was not found in the remote manifest.");
+            await dependency.Install(fileService, manifestService, snapService, systemdService, logger);
         }
 
-        // Place linking file in the content snap's $SNAP_COMMON
-        await fileService.PlaceLinkageFile(Key);
+        var transaction = new InstallationTransaction(Key);
 
-        // Install Systemd mount units
-        await PlaceMountUnits(fileService, manifestService, systemdService, logger);
-
-        // Install update watcher unit
-        await PlacePathUnits(fileService, systemdService, logger);
-
-        // Register the installation of this component in the local manifest file
-        await manifestService.Add(this);
-
-        foreach (var dependency in Dependencies)
+        try
         {
-            var component = manifestService.Remote.First(c => c.Key == dependency);
-            await component.Install(fileService, manifestService, snapService, systemdService, logger);
+            // Install content snap on the machine
+            if (!snapService.IsSnapInstalled(Key))
+            {
+                // Gather highest channel available
+                var snapInfo = await snapService.FindSnap(Key);
+
+                var channel = snapInfo?.Channel switch
+                {
+                    "candidate" => SnapChannel.Candidate,
+                    "beta" => SnapChannel.Beta,
+                    "edge" => SnapChannel.Edge,
+                    _ => SnapChannel.Stable
+                };
+
+                transaction.MarkSnapInstallAttempted();
+                var result = await snapService.Install(Key, channel);
+                if (!result.IsSuccess) throw new ApplicationException(result.StandardError);
+            }
+
+            // Place linking file in the content snap's $SNAP_COMMON
+            transaction.MarkLinkageFilePlacementAttempted();
+            await fileService.PlaceLinkageFile(Key);
+
+            // Install Systemd mount units
+            transaction.MarkMountUnitsPlacementAttempted();
+            await PlaceMountUnits(fileService, manifestService, systemdService, logger);
+
+            // Install update watcher unit
+            transaction.MarkPathUnitsPlacementAttempted();
+            await PlacePathUnits(fileService, systemdService, logger);
+
+            // Register the installation of this component in the local manifest file
+            // only after all installation steps have succeeded.
+            await manifestService.Add(this);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError($"Installation of {Key} failed: {ex.Message}");
+            logger?.LogError("Rolling back changes...");
+            await transaction.Rollback(fileService, manifestService, snapService, systemdService, logger);
+            throw;
         }
 
         InstallationFinished?.Invoke(this, new InstallationFinishedEventArgs(Key));
@@ -231,7 +251,7 @@ public class Component
         logger?.LogDebug($"Started {Key}-update-watcher.path");
     }
 
-    private async Task RemovePathUnits(IFileService fileService, ISystemdService systemdService,
+    internal async Task RemovePathUnits(IFileService fileService, ISystemdService systemdService,
         ILogger? logger = default)
     {
         var result = await systemdService.DisableUnit($"{Key}-update-watcher.path");

--- a/src/Dotnet.Installer.Core/Models/Component.cs
+++ b/src/Dotnet.Installer.Core/Models/Component.cs
@@ -48,8 +48,8 @@ public class Component
         // and throw, preventing this component from being registered as installed.
         foreach (var dependencyKey in Dependencies)
         {
-            var dependency = manifestService.Remote.FirstOrDefault(c => c.Key == dependencyKey) ?? throw new ApplicationException(
-                    $"Dependency {dependencyKey} for component {Key} was not found in the remote manifest.");
+            var dependency = manifestService.Merged.FirstOrDefault(c => c.Key == dependencyKey) ?? throw new ApplicationException(
+                    $"Dependency {dependencyKey} for component {Key} was not found in the manifest.");
             await dependency.Install(fileService, manifestService, snapService, systemdService, logger);
         }
 
@@ -77,7 +77,8 @@ public class Component
             }
 
             // Place linking file in the content snap's $SNAP_COMMON
-            transaction.MarkLinkageFilePlacementAttempted();
+            var linkageFileExistedBeforePlacement = fileService.FileExists(Path.Join("/", "var", "snap", Key, "common", "dotnet-installer"));
+            transaction.MarkLinkageFilePlacementAttempted(linkageFileExistedBeforePlacement);
             await fileService.PlaceLinkageFile(Key);
 
             // Install Systemd mount units
@@ -128,18 +129,23 @@ public class Component
         ISystemdService systemdService, ILogger? logger = default)
     {
         var units = new StringBuilder();
-        var unitPaths = fileService.EnumerateContentSnapMountFiles(Key);
+        var unitPaths = fileService.EnumerateContentSnapMountFiles(Key).ToList();
+
+        foreach (var unitPath in unitPaths)
+        {
+            units.AppendLine(unitPath.Split('/').Last());
+        }
+
+        // Save unit names before copying files so that, if any later step fails,
+        // rollback can use this tracker to remove any partially-copied units.
+        await fileService.PlaceUnitsFile(manifestService.SnapConfigurationLocation, contentSnapName: Key,
+            units.ToString());
 
         foreach (var unitPath in unitPaths)
         {
             logger?.LogDebug($"Copying {unitPath} to systemd directory.");
             fileService.InstallSystemdMountUnit(unitPath);
-            units.AppendLine(unitPath.Split('/').Last());
         }
-
-        // Save unit names to component .mounts file
-        await fileService.PlaceUnitsFile(manifestService.SnapConfigurationLocation, contentSnapName: Key,
-            units.ToString());
 
         var result = await systemdService.DaemonReload();
         if (!result.IsSuccess)

--- a/src/Dotnet.Installer.Core/Models/InstallationTransaction.cs
+++ b/src/Dotnet.Installer.Core/Models/InstallationTransaction.cs
@@ -14,6 +14,7 @@ public class InstallationTransaction(string componentKey)
     private bool _mountUnitsPlacementAttempted;
     private bool _pathUnitsPlacementAttempted;
     private bool _linkageFilePlacementAttempted;
+    private bool _linkageFileExistedBeforePlacement;
 
     /// <summary>
     /// Marks that the content snap installation was attempted. If the installation fails,
@@ -26,11 +27,16 @@ public class InstallationTransaction(string componentKey)
 
     /// <summary>
     /// Marks that the linkage file placement was attempted. If the placement fails,
-    /// rollback will try to remove the linkage file if it is present.
+    /// rollback will try to remove the linkage file only if it was created during this transaction.
     /// </summary>
-    public void MarkLinkageFilePlacementAttempted()
+    /// <param name="existedBeforePlacement">
+    /// <see langword="true"/> if the linkage file already existed before the current installation attempt;
+    /// <see langword="false"/> if this transaction created it.
+    /// </param>
+    public void MarkLinkageFilePlacementAttempted(bool existedBeforePlacement)
     {
         _linkageFilePlacementAttempted = true;
+        _linkageFileExistedBeforePlacement = existedBeforePlacement;
     }
 
     /// <summary>
@@ -99,7 +105,7 @@ public class InstallationTransaction(string componentKey)
             }
         }
 
-        if (_linkageFilePlacementAttempted)
+        if (_linkageFilePlacementAttempted && !_linkageFileExistedBeforePlacement)
         {
             try
             {

--- a/src/Dotnet.Installer.Core/Models/InstallationTransaction.cs
+++ b/src/Dotnet.Installer.Core/Models/InstallationTransaction.cs
@@ -1,0 +1,130 @@
+using Dotnet.Installer.Core.Services.Contracts;
+
+namespace Dotnet.Installer.Core.Models;
+
+/// <summary>
+/// Tracks changes performed during a <see cref="Dotnet.Installer.Core.Models.Component.Install()"/> so that they can be
+/// rolled back if any step fails. Only changes made by the current installation are rolled
+/// back; successfully installed dependencies are left untouched.
+/// </summary>
+public class InstallationTransaction(string componentKey)
+{
+    private readonly string _componentKey = componentKey;
+    private bool _snapInstallAttempted;
+    private bool _mountUnitsPlacementAttempted;
+    private bool _pathUnitsPlacementAttempted;
+    private bool _linkageFilePlacementAttempted;
+
+    /// <summary>
+    /// Marks that the content snap installation was attempted. If the installation fails,
+    /// rollback will try to remove the snap if it is present.
+    /// </summary>
+    public void MarkSnapInstallAttempted()
+    {
+        _snapInstallAttempted = true;
+    }
+
+    /// <summary>
+    /// Marks that the linkage file placement was attempted. If the placement fails,
+    /// rollback will try to remove the linkage file if it is present.
+    /// </summary>
+    public void MarkLinkageFilePlacementAttempted()
+    {
+        _linkageFilePlacementAttempted = true;
+    }
+
+    /// <summary>
+    /// Marks that the mount unit placement was attempted. If the placement fails,
+    /// rollback will try to remove any mount units that may have been partially placed.
+    /// </summary>
+    public void MarkMountUnitsPlacementAttempted()
+    {
+        _mountUnitsPlacementAttempted = true;
+    }
+
+    /// <summary>
+    /// Marks that the path unit placement was attempted. If the placement fails,
+    /// rollback will try to remove any path units that may have been partially placed.
+    /// </summary>
+    public void MarkPathUnitsPlacementAttempted()
+    {
+        _pathUnitsPlacementAttempted = true;
+    }
+
+    public async Task Rollback(IFileService fileService, IManifestService manifestService,
+        ISnapService snapService, ISystemdService systemdService, ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        logger?.LogDebug($"Rolling back installation of {_componentKey}");
+
+        if (_mountUnitsPlacementAttempted)
+        {
+            try
+            {
+                var component = new Component
+                {
+                    Key = _componentKey,
+                    Name = string.Empty,
+                    Description = string.Empty,
+                    MajorVersion = 0,
+                    IsLts = false,
+                    Dependencies = []
+                };
+                await component.RemoveMountUnits(fileService, manifestService, systemdService, logger);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning($"Could not remove mount units during rollback: {ex.Message}");
+            }
+        }
+
+        if (_pathUnitsPlacementAttempted)
+        {
+            try
+            {
+                var component = new Component
+                {
+                    Key = _componentKey,
+                    Name = string.Empty,
+                    Description = string.Empty,
+                    MajorVersion = 0,
+                    IsLts = false,
+                    Dependencies = []
+                };
+                await component.RemovePathUnits(fileService, systemdService, logger);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning($"Could not remove path units during rollback: {ex.Message}");
+            }
+        }
+
+        if (_linkageFilePlacementAttempted)
+        {
+            try
+            {
+                fileService.RemoveLinkageFile(_componentKey);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning($"Could not remove linkage file during rollback: {ex.Message}");
+            }
+        }
+
+        if (_snapInstallAttempted && snapService.IsSnapInstalled(_componentKey))
+        {
+            try
+            {
+                var result = await snapService.Remove(_componentKey, purge: true, cancellationToken);
+                if (!result.IsSuccess)
+                {
+                    logger?.LogWarning($"Could not remove snap during rollback: {result.StandardError}");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning($"Could not remove snap during rollback: {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/Dotnet.Installer.Core/Services/Contracts/IFileService.cs
+++ b/src/Dotnet.Installer.Core/Services/Contracts/IFileService.cs
@@ -11,6 +11,7 @@ public interface IFileService
     void InstallSystemdPathUnit(string snapName);
     void UninstallSystemdPathUnit(string snapName);
     Task PlaceLinkageFile(string contentSnapName);
+    void RemoveLinkageFile(string contentSnapName);
     Task PlaceUnitsFile(string snapConfigDirLocation, string contentSnapName, string units);
     Task<string[]> ReadUnitsFile(string snapConfigDirLocation, string contentSnapName);
     void DeleteUnitsFile(string snapConfigDirLocation, string contentSnapName);

--- a/src/Dotnet.Installer.Core/Services/Implementations/FileService.cs
+++ b/src/Dotnet.Installer.Core/Services/Implementations/FileService.cs
@@ -78,6 +78,20 @@ public class FileService : IFileService
             Encoding.UTF8);
     }
 
+    /// <summary>
+    /// Removes the linkage file that marks that a .NET content snap is being tracked by the
+    /// .NET installer tool.
+    /// </summary>
+    /// <param name="contentSnapName">The name of the .NET content snap.</param>
+    public void RemoveLinkageFile(string contentSnapName)
+    {
+        var path = Path.Join("/", "var", "snap", contentSnapName, "common", "dotnet-installer");
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
     public Task PlaceUnitsFile(string snapConfigDirLocation, string contentSnapName, string units)
     {
         var mountsFileName = $"{contentSnapName}.mounts";

--- a/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
@@ -218,4 +218,219 @@ public class ComponentTests
         Assert.False(component1.IsInstalled);
         Assert.Empty(installedComponents);
     }
+
+    [Fact]
+    public async Task Install_WithDependencyFailure_ShouldNotAddParentToManifest()
+    {
+        // Arrange
+        var parent = new Component
+        {
+            Dependencies = ["dep1"],
+            Description = "Parent",
+            Key = "parent",
+            Name = "name",
+            MajorVersion = 8,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now
+        };
+
+        var dependency = new Component
+        {
+            Dependencies = [],
+            Description = "Dependency",
+            Key = "dep1",
+            Name = "name",
+            MajorVersion = 8,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now
+        };
+
+        var fileService = new Mock<IFileService>();
+        var manifestService = new Mock<IManifestService>();
+        var snapService = new Mock<ISnapService>();
+        var systemDService = new Mock<ISystemdService>();
+
+        manifestService.Setup(s => s.Remote).Returns([parent, dependency]);
+
+        snapService.Setup(s => s.Install(It.IsAny<string>(), It.IsAny<SnapChannel>(), CancellationToken.None))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+
+        // Make the dependency fail when installing its mount units
+        systemDService.Setup(s => s.DaemonReload())
+            .ReturnsAsync(() => new Terminal.InvocationResult(1, string.Empty, "daemon reload failed"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ApplicationException>(() =>
+            parent.Install(fileService.Object, manifestService.Object, snapService.Object, systemDService.Object));
+
+        manifestService.Verify(m => m.Add(parent, CancellationToken.None), Times.Never);
+    }
+
+    [Fact]
+    public async Task Install_WhenMountUnitsFail_ShouldRollbackSnapInstall()
+    {
+        // Arrange
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "Component",
+            Key = "dotnet-sdk-80",
+            Name = "sdk",
+            MajorVersion = 8,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now
+        };
+
+        var fileService = new Mock<IFileService>();
+        var manifestService = new Mock<IManifestService>();
+        var snapService = new Mock<ISnapService>();
+        var systemDService = new Mock<ISystemdService>();
+
+        snapService.SetupSequence(s => s.IsSnapInstalled(component.Key))
+            .Returns(false)
+            .Returns(true);
+        snapService.Setup(s => s.Install(component.Key, It.IsAny<SnapChannel>(), CancellationToken.None))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        snapService.Setup(s => s.FindSnap(component.Key, CancellationToken.None))
+            .ReturnsAsync(new SnapInfo(component.Key, "8.0.0", "1", "stable", new SnapPublisher("id", "dotnet", ".NET", "verified")));
+
+        fileService.Setup(f => f.EnumerateContentSnapMountFiles(component.Key))
+            .Returns(["/snap/dotnet-sdk-80/current/mounts/unit.mount"]);
+        fileService.Setup(f => f.ReadUnitsFile(It.IsAny<string>(), component.Key))
+            .ReturnsAsync(["unit.mount"]);
+
+        // Fail daemon-reload so PlaceMountUnits throws
+        systemDService.Setup(s => s.DaemonReload())
+            .ReturnsAsync(new Terminal.InvocationResult(1, string.Empty, "daemon reload failed"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ApplicationException>(() =>
+            component.Install(fileService.Object, manifestService.Object, snapService.Object, systemDService.Object));
+
+        manifestService.Verify(m => m.Add(component, CancellationToken.None), Times.Never);
+        snapService.Verify(s => s.Remove(component.Key, true, CancellationToken.None), Times.Once);
+        fileService.Verify(f => f.PlaceLinkageFile(component.Key), Times.Once);
+        fileService.Verify(f => f.RemoveLinkageFile(component.Key), Times.Once);
+    }
+
+    [Fact]
+    public async Task Install_WhenPathUnitsFail_ShouldRollbackMountUnitsAndSnap()
+    {
+        // Arrange
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "Component",
+            Key = "dotnet-sdk-80",
+            Name = "sdk",
+            MajorVersion = 8,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now
+        };
+
+        var fileService = new Mock<IFileService>();
+        var manifestService = new Mock<IManifestService>();
+        var snapService = new Mock<ISnapService>();
+        var systemDService = new Mock<ISystemdService>();
+
+        snapService.SetupSequence(s => s.IsSnapInstalled(component.Key))
+            .Returns(false)
+            .Returns(true);
+        snapService.Setup(s => s.Install(component.Key, It.IsAny<SnapChannel>(), CancellationToken.None))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        snapService.Setup(s => s.FindSnap(component.Key, CancellationToken.None))
+            .ReturnsAsync(new SnapInfo(component.Key, "8.0.0", "1", "stable", new SnapPublisher("id", "dotnet", ".NET", "verified")));
+
+        fileService.Setup(f => f.EnumerateContentSnapMountFiles(component.Key))
+            .Returns(["/snap/dotnet-sdk-80/current/mounts/unit.mount"]);
+        fileService.Setup(f => f.ReadUnitsFile(It.IsAny<string>(), component.Key))
+            .ReturnsAsync(["unit.mount"]);
+
+        // Succeed mount units
+        systemDService.Setup(s => s.DaemonReload())
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        systemDService.Setup(s => s.EnableUnit(It.IsAny<string>()))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        systemDService.Setup(s => s.StartUnit(It.IsAny<string>()))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+
+        // Fail path unit enable
+        systemDService.Setup(s => s.EnableUnit($"{component.Key}-update-watcher.path"))
+            .ReturnsAsync(new Terminal.InvocationResult(1, string.Empty, "enable failed"));
+        systemDService.Setup(s => s.DisableUnit($"{component.Key}-update-watcher.path"))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        systemDService.Setup(s => s.StopUnit($"{component.Key}-update-watcher.path"))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ApplicationException>(() =>
+            component.Install(fileService.Object, manifestService.Object, snapService.Object, systemDService.Object));
+
+        manifestService.Verify(m => m.Add(component, CancellationToken.None), Times.Never);
+        snapService.Verify(s => s.Remove(component.Key, true, CancellationToken.None), Times.Once);
+        fileService.Verify(f => f.PlaceLinkageFile(component.Key), Times.Once);
+        fileService.Verify(f => f.RemoveLinkageFile(component.Key), Times.Once);
+        fileService.Verify(f => f.UninstallSystemdPathUnit(component.Key), Times.Once);
+    }
+
+    [Fact]
+    public async Task Install_WhenManifestAddFails_ShouldRollbackAllInstallationSteps()
+    {
+        // Arrange
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "Component",
+            Key = "dotnet-sdk-80",
+            Name = "sdk",
+            MajorVersion = 8,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now
+        };
+
+        var fileService = new Mock<IFileService>();
+        var manifestService = new Mock<IManifestService>();
+        var snapService = new Mock<ISnapService>();
+        var systemDService = new Mock<ISystemdService>();
+
+        snapService.SetupSequence(s => s.IsSnapInstalled(component.Key))
+            .Returns(false)
+            .Returns(true);
+        snapService.Setup(s => s.Install(component.Key, It.IsAny<SnapChannel>(), CancellationToken.None))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        snapService.Setup(s => s.FindSnap(component.Key, CancellationToken.None))
+            .ReturnsAsync(new SnapInfo(component.Key, "8.0.0", "1", "stable", new SnapPublisher("id", "dotnet", ".NET", "verified")));
+
+        fileService.Setup(f => f.EnumerateContentSnapMountFiles(component.Key))
+            .Returns(["/snap/dotnet-sdk-80/current/mounts/unit.mount"]);
+        fileService.Setup(f => f.ReadUnitsFile(It.IsAny<string>(), component.Key))
+            .ReturnsAsync(["unit.mount"]);
+
+        systemDService.Setup(s => s.DaemonReload())
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        systemDService.Setup(s => s.EnableUnit(It.IsAny<string>()))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        systemDService.Setup(s => s.StartUnit(It.IsAny<string>()))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        systemDService.Setup(s => s.DisableUnit(It.IsAny<string>()))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+        systemDService.Setup(s => s.StopUnit(It.IsAny<string>()))
+            .ReturnsAsync(new Terminal.InvocationResult(0, string.Empty, string.Empty));
+
+        manifestService.Setup(m => m.Add(component, CancellationToken.None))
+            .ThrowsAsync(new ApplicationException("manifest write failed"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ApplicationException>(() =>
+            component.Install(fileService.Object, manifestService.Object, snapService.Object, systemDService.Object));
+
+        snapService.Verify(s => s.Remove(component.Key, true, CancellationToken.None), Times.Once);
+        fileService.Verify(f => f.RemoveLinkageFile(component.Key), Times.Once);
+        fileService.Verify(f => f.UninstallSystemdPathUnit(component.Key), Times.Once);
+    }
 }

--- a/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Models/ComponentTests.cs
@@ -143,6 +143,7 @@ public class ComponentTests
         var systemDService = new Mock<ISystemdService>();
 
         manifestService.Setup(s => s.Remote).Returns([component1, component2, component3]);
+        manifestService.Setup(s => s.Merged).Returns([component1, component2, component3]);
         manifestService.Setup(e => e.Add(
                 It.IsAny<Component>(), CancellationToken.None))
             .Callback((Component c, CancellationToken cancellationToken) =>


### PR DESCRIPTION
## Summary

Introduces a dependency-first installation model and makes Component.Install transactional, ensuring that a failed installation does not leave the system in an inconsistent or partially broken state.

## Problem

Previously, `Component.Install` would:

1. Install the requested component's content snap
2. Place and start its mount/path units
3. Register it in the local manifest
4. Only then install its dependencies

If a dependency install failed, the parent component was already recorded as installed with active systemd units, leaving the system partially broken and requiring manual cleanup.

## Changes

1. Dependency-First Installation
- The installer now recursively resolves and installs all dependencies before attempting to install the requested component (e.g., ensuring dotnet-runtime-80 is fully installed before starting on dotnet-sdk-80).

2. Transactional Rollbacks
- Introduced InstallationTransaction to track attempted installation steps. If any step in the chain fails, the transaction rolls back the system by:
   - Removing newly installed content snaps
   - Removing linkage files (via the newly added IFileService.RemoveLinkageFile())
   - Removing mount and path units

3. Atomic State Management
- Deferred the local manifest update until after all installation steps and dependencies succeed.
- Improved failure logging to clearly display the root cause before announcing a rollback.

## Testing

Added component tests [here](https://github.com/canonical/dotnet-snap/pull/34/changes#diff-3a24b19318065d63ed82db849be06a618b9ea1a8429514b2f9caa2110f46ead6), to verify the rollback mechanism works across all failure domains (dependency failure, mount-unit failure, path-unit failure, and manifest-add failure).

Result
<img width="1433" height="333" alt="image" src="https://github.com/user-attachments/assets/ea278a51-0a18-41c9-99a6-7c86d107fb72" />