### PR TITLE
feat: adding info command and list flags

### DIFF
--- a/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
@@ -25,12 +25,16 @@ public class InfoCommand : Command
 
         var componentArgument = new Argument<string>(
             name: "component",
-            description: "The .NET component name ('runtime', 'aspnetcore-runtime', 'sdk').",
-            getDefaultValue: () => "sdk");
+            description: "The .NET component name ('runtime', 'aspnetcore-runtime', 'sdk').")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
         var versionArgument = new Argument<string>(
             name: "version",
-            description: "The .NET component version (e.g. '8' or '8.0'), lts, latest.",
-            getDefaultValue: () => "latest");
+            description: "The .NET component version (e.g. '8' or '8.0'), lts, latest.")
+        {
+            Arity = ArgumentArity.ZeroOrOne
+        };
 
         AddArgument(componentArgument);
         AddArgument(versionArgument);
@@ -38,8 +42,27 @@ public class InfoCommand : Command
         this.SetHandler(Handle, componentArgument, versionArgument);
     }
 
-    private async Task Handle(string componentName, string version)
+    private async Task Handle(string? componentName, string? version)
     {
+        if (string.IsNullOrWhiteSpace(componentName))
+        {
+            _logger.LogError("Missing component name. " +
+                             $"Valid components are: {Constants.DotnetRuntimeComponentName}, " +
+                             $"{Constants.AspnetCoreRuntimeComponentName}, {Constants.SdkComponentName}. " +
+                             "Example: dotnet installer info sdk lts");
+            Environment.Exit(-1);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            _logger.LogError($"Missing version for component '{componentName}'. " +
+                             "Valid versions are: a major version (e.g. '8' or '8.0'), lts, latest. " +
+                             $"Example: dotnet installer info {componentName} lts");
+            Environment.Exit(-1);
+            return;
+        }
+
 #if INCLUDE_PRERELEASE
         const bool includePrerelease = true;
 #else
@@ -53,7 +76,8 @@ public class InfoCommand : Command
             if (component is null)
             {
                 _logger.LogError($"The requested component '{componentName} {version}' does not exist. " +
-                                 "Valid components are: runtime, aspnetcore-runtime, sdk. " +
+                                 $"Valid components are: {Constants.DotnetRuntimeComponentName}, " +
+                                 $"{Constants.AspnetCoreRuntimeComponentName}, {Constants.SdkComponentName}. " +
                                  "Example: dotnet installer info sdk lts");
                 Environment.Exit(-1);
             }

--- a/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
@@ -1,0 +1,169 @@
+using System.CommandLine;
+using System.Text;
+using Dotnet.Installer.Core.Models;
+using Dotnet.Installer.Core.Services.Contracts;
+using Dotnet.Installer.Core.Types;
+using Spectre.Console;
+
+namespace Dotnet.Installer.Console.Commands;
+
+public class InfoCommand : Command
+{
+    private readonly IManifestService _manifestService;
+    private readonly ISnapService _snapService;
+    private readonly ILogger _logger;
+
+    public InfoCommand(
+        IManifestService manifestService,
+        ISnapService snapService,
+        ILogger logger)
+        : base("info", "Shows detailed information about a .NET component")
+    {
+        _manifestService = manifestService ?? throw new ArgumentNullException(nameof(manifestService));
+        _snapService = snapService ?? throw new ArgumentNullException(nameof(snapService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var componentArgument = new Argument<string>(
+            name: "component",
+            description: "The .NET component name ('runtime', 'aspnetcore-runtime', 'sdk').",
+            getDefaultValue: () => "sdk");
+        var versionArgument = new Argument<string>(
+            name: "version",
+            description: "The .NET component version (e.g. '8' or '8.0'), lts, latest.",
+            getDefaultValue: () => "latest");
+
+        AddArgument(componentArgument);
+        AddArgument(versionArgument);
+
+        this.SetHandler(Handle, componentArgument, versionArgument);
+    }
+
+    private async Task Handle(string componentName, string version)
+    {
+#if INCLUDE_PRERELEASE
+        const bool includePrerelease = true;
+#else
+        const bool includePrerelease = false;
+#endif
+        try
+        {
+            await _manifestService.Initialize(includeUnsupported: true, includePrerelease);
+
+            var component = _manifestService.MatchRemoteComponent(componentName, version);
+            if (component is null)
+            {
+                _logger.LogError($"The requested component '{componentName} {version}' does not exist. " +
+                                 "Valid components are: runtime, aspnetcore-runtime, sdk. " +
+                                 "Example: dotnet installer info sdk lts");
+                Environment.Exit(-1);
+            }
+
+            var installed = _manifestService.Local.Any(c => c.Key == component.Key);
+            var (actualVersion, channel) = await GetSnapInfo(component.Key, installed);
+
+            RenderInfo(component, installed, actualVersion, channel);
+            RenderDependencies(component);
+            if (installed) RenderReverseDependencies(component.Key);
+        }
+        catch (ApplicationException ex)
+        {
+            _logger.LogError(ex.Message);
+            Environment.Exit(-1);
+        }
+    }
+
+    private async Task<(DotnetVersion? Version, string Channel)> GetSnapInfo(string key, bool installed)
+    {
+        try
+        {
+            SnapInfo? snap;
+            if (installed)
+            {
+                snap = await _snapService.GetInstalledSnap(key);
+            }
+            else
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                snap = await _snapService.FindSnap(key, cts.Token);
+            }
+
+            if (snap is null) return (null, "unknown");
+            return (snap.ParseVersionAsDotnetVersion(), snap.Channel);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogDebug(exception.Message);
+            return (null, "unknown");
+        }
+    }
+
+    private void RenderInfo(Component component, bool installed, DotnetVersion? version, string channel)
+    {
+        var title = new StringBuilder(component.Description);
+        if (version is not null) title.Append($" {version}");
+        else title.Append($" {component.MajorVersion}");
+
+        var grid = new Grid();
+        grid.AddColumn();
+        grid.AddColumn();
+
+        grid.AddRow("Status:", installed ? "[green]Installed[/]" : "[blue]Available[/]");
+        grid.AddRow("LTS:", component.IsLts ? "Yes" : "No");
+        grid.AddRow("Grade:", component.Grade.ToString());
+        grid.AddRow("Channel:", channel);
+        grid.AddRow("EOL:", OutputFormat.Eol(component, installed));
+
+        var panel = new Panel(grid)
+        {
+            Header = new PanelHeader(title.ToString()),
+            Expand = true
+        };
+
+        AnsiConsole.Write(panel);
+    }
+
+    private void RenderDependencies(Component component)
+    {
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(new Markup("[bold]Dependencies[/]"));
+        AnsiConsole.WriteLine();
+
+        if (!component.Dependencies.Any())
+        {
+            AnsiConsole.WriteLine("None");
+            return;
+        }
+
+        var tree = new Tree(string.Empty);
+        foreach (var dependencyKey in component.Dependencies)
+        {
+            var dependency = _manifestService.Merged.FirstOrDefault(c => c.Key == dependencyKey);
+            var label = dependency is null ? dependencyKey : $"{dependency.Description} {dependency.MajorVersion}";
+            tree.AddNode(label);
+        }
+
+        AnsiConsole.Write(tree);
+    }
+
+    private void RenderReverseDependencies(string key)
+    {
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(new Markup("[bold]Required by[/]"));
+        AnsiConsole.WriteLine();
+
+        var reverseDependencies = new DependencyTree(_manifestService.Local).GetReverseDependencies(key);
+        if (reverseDependencies.Count == 0)
+        {
+            AnsiConsole.WriteLine("Nothing installed depends on this component.");
+            return;
+        }
+
+        var tree = new Tree(string.Empty);
+        foreach (var dependency in reverseDependencies)
+        {
+            tree.AddNode($"{dependency.Description} {dependency.MajorVersion}");
+        }
+
+        AnsiConsole.Write(tree);
+    }
+}

--- a/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
@@ -54,6 +54,16 @@ public class InfoCommand : Command
             return;
         }
 
+        if (!IsValidComponentName(componentName))
+        {
+            _logger.LogError($"Invalid component name '{componentName}'. " +
+                             $"Valid components are: {Constants.DotnetRuntimeComponentName}, " +
+                             $"{Constants.AspnetCoreRuntimeComponentName}, {Constants.SdkComponentName}. " +
+                             "Example: dotnet installer info sdk lts");
+            Environment.Exit(-1);
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(version))
         {
             _logger.LogError($"Missing version for component '{componentName}'. " +
@@ -94,6 +104,13 @@ public class InfoCommand : Command
             _logger.LogError(ex.Message);
             Environment.Exit(-1);
         }
+    }
+
+    private static bool IsValidComponentName(string componentName)
+    {
+        return componentName.Equals(Constants.DotnetRuntimeComponentName, StringComparison.CurrentCultureIgnoreCase)
+               || componentName.Equals(Constants.AspnetCoreRuntimeComponentName, StringComparison.CurrentCultureIgnoreCase)
+               || componentName.Equals(Constants.SdkComponentName, StringComparison.CurrentCultureIgnoreCase);
     }
 
     private async Task<(DotnetVersion? Version, string Channel)> GetSnapInfo(string key, bool installed)

--- a/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InfoCommand.cs
@@ -85,10 +85,26 @@ public class InfoCommand : Command
             var component = _manifestService.MatchRemoteComponent(componentName, version);
             if (component is null)
             {
-                _logger.LogError($"The requested component '{componentName} {version}' does not exist. " +
-                                 $"Valid components are: {Constants.DotnetRuntimeComponentName}, " +
-                                 $"{Constants.AspnetCoreRuntimeComponentName}, {Constants.SdkComponentName}. " +
-                                 "Example: dotnet installer info sdk lts");
+                var availableVersions = _manifestService.Remote
+                    .Where(c => c.Name.Equals(componentName, StringComparison.CurrentCultureIgnoreCase))
+                    .Select(c => c.MajorVersion)
+                    .Distinct()
+                    .OrderByDescending(v => v)
+                    .ToList();
+
+                if (availableVersions.Count > 0)
+                {
+                    _logger.LogError($"The requested version '{version}' does not exist for component '{componentName}'. " +
+                                     $"Available versions are: {string.Join(", ", availableVersions)}. " +
+                                     $"Example: dotnet installer info {componentName} {availableVersions.First()}");
+                }
+                else
+                {
+                    _logger.LogError($"The requested component '{componentName} {version}' does not exist. " +
+                                     $"Valid components are: {Constants.DotnetRuntimeComponentName}, " +
+                                     $"{Constants.AspnetCoreRuntimeComponentName}, {Constants.SdkComponentName}. " +
+                                     "Example: dotnet installer info sdk lts");
+                }
                 Environment.Exit(-1);
             }
 

--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -58,7 +58,9 @@ public class InstallCommand : Command
 
                 if (requestedComponent is null)
                 {
-                    _logger.LogError($"The requested component {component} {version} does not exist.");
+                    _logger.LogError($"The requested component '{component} {version}' does not exist. " +
+                                    "Valid components are: runtime, aspnetcore-runtime, sdk. " +
+                                    "Example: dotnet installer install sdk lts");
                     Environment.Exit(-1);
                 }
 

--- a/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/InstallCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using Dotnet.Installer.Core.Models;
 using Dotnet.Installer.Core.Services.Contracts;
 
 namespace Dotnet.Installer.Console.Commands;
@@ -59,7 +60,8 @@ public class InstallCommand : Command
                 if (requestedComponent is null)
                 {
                     _logger.LogError($"The requested component '{component} {version}' does not exist. " +
-                                    "Valid components are: runtime, aspnetcore-runtime, sdk. " +
+                                    $"Valid components are: {Constants.DotnetRuntimeComponentName}, " +
+                                    $"{Constants.AspnetCoreRuntimeComponentName}, {Constants.SdkComponentName}. " +
                                     "Example: dotnet installer install sdk lts");
                     Environment.Exit(-1);
                 }

--- a/src/Dotnet.Installer.Console/Commands/ListCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/ListCommand.cs
@@ -32,6 +32,20 @@ public class ListCommand : Command
                 IsRequired = false
             };
 
+        var installedOption = new Option<bool>(
+            name: "--installed",
+            description: "Show only installed components.")
+            {
+                IsRequired = false
+            };
+
+        var ltsOption = new Option<bool>(
+            name: "--lts",
+            description: "Show only LTS components.")
+            {
+                IsRequired = false
+            };
+
         var timeoutOption = new Option<uint>(
             name: "--timeout",
             description: "The timeout for requesting the version of a .NET component " +
@@ -42,12 +56,14 @@ public class ListCommand : Command
         };
 
         AddOption(includeUnsupportedOption);
+        AddOption(installedOption);
+        AddOption(ltsOption);
         AddOption(timeoutOption);
 
-        this.SetHandler(Handle, includeUnsupportedOption, timeoutOption);
+        this.SetHandler(Handle, includeUnsupportedOption, installedOption, ltsOption, timeoutOption);
     }
 
-    private async Task Handle(bool includeUnsupported, uint timeoutInMilliseconds)
+    private async Task Handle(bool includeUnsupported, bool installedOnly, bool ltsOnly, uint timeoutInMilliseconds)
     {
 #if INCLUDE_PRERELEASE
         const bool includePrerelease = true;
@@ -58,6 +74,21 @@ public class ListCommand : Command
         {
             await _manifestService.Initialize(includeUnsupported, includePrerelease);
 
+            var components = installedOnly
+                ? _manifestService.Local.ToList()
+                : _manifestService.Merged.ToList();
+
+            if (ltsOnly) components = components.Where(c => c.IsLts).ToList();
+
+            if (components.Count == 0)
+            {
+                var message = installedOnly
+                    ? "You don't have any .NET components installed. Run 'dotnet installer install sdk lts' to install the latest LTS SDK."
+                    : "No .NET components found.";
+                AnsiConsole.WriteLine(message);
+                return;
+            }
+
             var table = new Table();
 
             table.AddColumn(new TableColumn("Version"));
@@ -66,7 +97,6 @@ public class ListCommand : Command
             table.AddColumn(new TableColumn("SDK"));
             table.AddColumn(new TableColumn("End of Life"));
 
-            var components = _manifestService.Merged.ToList();
             var componentVersions = await GetComponentVersions(components, timeoutInMilliseconds).ConfigureAwait(false);
 
             foreach (var majorVersionGroup in components
@@ -91,42 +121,13 @@ public class ListCommand : Command
                     var component = majorVersionGroup.FirstOrDefault(
                         c => c.Name == name && c.MajorVersion == majorVersionGroup.Key);
 
-                    if (component is null)
-                    {
-                        return "[grey]-[/]";
-                    }
-
-                    var status = component.IsInstalled ? "[green][bold]Installed[/]" : "[blue][bold]Available[/]";
-
-                    var version = componentVersions[component.Key];
-                    status += version is null ? "[/]" : $" [[{version}]][/]";
-
-                    return status;
+                    return component is null ? "[grey]-[/]" : OutputFormat.Status(component, componentVersions[component.Key]);
                 }
 
                 string EndOfLifeStatus()
                 {
-                    var endOfLife = majorVersionGroup.First().EndOfLife;
-
-                    if (endOfLife is null)
-                    {
-                        return "[grey]-[/]";
-                    }
-
-                    var daysUntilEndOfLife = (endOfLife.Value - DateTime.Now).TotalDays;
-
-                    var eolString = $"[{(daysUntilEndOfLife <= 0d ? "bold red" : "green")}]{endOfLife:d}[/]";
-
-                    if (majorVersionGroup.Any(c => c.IsInstalled) && daysUntilEndOfLife is < 30d and > 0d)
-                    {
-                        eolString += $" [bold yellow]({daysUntilEndOfLife:N0} days left)[/]";
-                    }
-                    else if (daysUntilEndOfLife is < 90d and > 0d)
-                    {
-                        eolString += $" ({daysUntilEndOfLife:N0} days left)";
-                    }
-
-                    return eolString;
+                    var component = majorVersionGroup.First();
+                    return OutputFormat.Eol(component, majorVersionGroup.Any(c => c.IsInstalled));
                 }
             }
 

--- a/src/Dotnet.Installer.Console/Commands/ListCommand.cs
+++ b/src/Dotnet.Installer.Console/Commands/ListCommand.cs
@@ -82,9 +82,13 @@ public class ListCommand : Command
 
             if (components.Count == 0)
             {
-                var message = installedOnly
-                    ? "You don't have any .NET components installed. Run 'dotnet installer install sdk lts' to install the latest LTS SDK."
-                    : "No .NET components found.";
+                var message = (installedOnly, ltsOnly) switch
+                {
+                    (true, true) => "You don't have any LTS .NET components installed. Run 'dotnet installer install sdk lts' to install the latest LTS SDK.",
+                    (true, false) => "You don't have any .NET components installed. Run 'dotnet installer install sdk lts' to install the latest LTS SDK.",
+                    (false, true) => "No LTS .NET components found.",
+                    _ => "No .NET components found."
+                };
                 AnsiConsole.WriteLine(message);
                 return;
             }

--- a/src/Dotnet.Installer.Console/OutputFormat.cs
+++ b/src/Dotnet.Installer.Console/OutputFormat.cs
@@ -1,0 +1,37 @@
+using Dotnet.Installer.Core.Models;
+using Dotnet.Installer.Core.Types;
+
+namespace Dotnet.Installer.Console;
+
+public static class OutputFormat
+{
+    public static string Status(Component component, DotnetVersion? version = null)
+    {
+        var status = component.IsInstalled ? "[green][bold]Installed[/]" : "[blue][bold]Available[/]";
+        status += version is null ? "[/]" : $" [[{version}]][/]";
+        return status;
+    }
+
+    public static string Eol(Component component, bool installed)
+    {
+        if (component.Grade == Grade.Preview) return "[yellow]Preview[/]";
+        if (component.Grade == Grade.Rc) return "[yellow]RC[/]";
+
+        var endOfLife = component.EndOfLife;
+        if (endOfLife is null) return "[grey]-[/]";
+
+        var daysUntilEndOfLife = (endOfLife.Value - DateTime.Now).TotalDays;
+        var eolString = $"[{(daysUntilEndOfLife <= 0d ? "bold red" : "green")}]{endOfLife:d}[/]";
+
+        if (installed && daysUntilEndOfLife is < 30d and > 0d)
+        {
+            eolString += $" [bold yellow]({daysUntilEndOfLife:N0} days left)[/]";
+        }
+        else if (daysUntilEndOfLife is < 90d and > 0d)
+        {
+            eolString += $" ({daysUntilEndOfLife:N0} days left)";
+        }
+
+        return eolString;
+    }
+}

--- a/src/Dotnet.Installer.Console/Program.cs
+++ b/src/Dotnet.Installer.Console/Program.cs
@@ -38,7 +38,8 @@ class Program
             new EnvironmentCommand(fileService, manifestService, systemDService, logger),
             new ListCommand(fileService, manifestService, snapService, logger),
             new InstallCommand(fileService, manifestService, snapService, systemDService, logger),
-            new RemoveCommand(fileService, manifestService, snapService, systemDService, logger)
+            new RemoveCommand(fileService, manifestService, snapService, systemDService, logger),
+            new InfoCommand(manifestService, snapService, logger)
         };
 
         var verboseOption = new Option<bool>("--verbose", "Enables debug output level verbosity.");

--- a/tests/Dotnet.Installer.Core.Tests/Dotnet.Installer.Core.Tests.csproj
+++ b/tests/Dotnet.Installer.Core.Tests/Dotnet.Installer.Core.Tests.csproj
@@ -24,6 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\src\Dotnet.Installer.Console\Dotnet.Installer.Console.csproj" />
       <ProjectReference Include="..\..\src\Dotnet.Installer.Core\Dotnet.Installer.Core.csproj" />
     </ItemGroup>
 

--- a/tests/Dotnet.Installer.Core.Tests/Formatting/OutputFormatTests.cs
+++ b/tests/Dotnet.Installer.Core.Tests/Formatting/OutputFormatTests.cs
@@ -1,0 +1,108 @@
+using Dotnet.Installer.Console;
+using Dotnet.Installer.Core.Models;
+
+namespace Dotnet.Installer.Core.Tests.Formatting;
+
+public class OutputFormatTests
+{
+    [Fact]
+    public void Status_WhenInstalled_ShouldContainInstalled()
+    {
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "SDK",
+            Key = "sdk-9",
+            Name = "sdk",
+            MajorVersion = 9,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now,
+            Installation = new Installation(DateTimeOffset.UtcNow)
+        };
+
+        var status = OutputFormat.Status(component);
+
+        Assert.Contains("Installed", status);
+    }
+
+    [Fact]
+    public void Status_WhenAvailable_ShouldContainAvailable()
+    {
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "SDK",
+            Key = "sdk-9",
+            Name = "sdk",
+            MajorVersion = 9,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now
+        };
+
+        var status = OutputFormat.Status(component);
+
+        Assert.Contains("Available", status);
+    }
+
+    [Fact]
+    public void Eol_WhenEndOfLifeIsNull_ShouldReturnDash()
+    {
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "SDK",
+            Key = "sdk-9",
+            Name = "sdk",
+            MajorVersion = 9,
+            IsLts = false,
+            Grade = Grade.Rtm,
+            EndOfLife = null
+        };
+
+        var eol = OutputFormat.Eol(component, installed: false);
+
+        Assert.Contains("-", eol);
+    }
+
+    [Fact]
+    public void Eol_WhenComponentIsPreview_ShouldIndicatePreview()
+    {
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "SDK",
+            Key = "sdk-11",
+            Name = "sdk",
+            MajorVersion = 11,
+            IsLts = false,
+            Grade = Grade.Preview,
+            EndOfLife = null
+        };
+
+        var eol = OutputFormat.Eol(component, installed: false);
+
+        Assert.Contains("Preview", eol);
+    }
+
+    [Fact]
+    public void Eol_WhenEndOfLifeIsPast_ShouldUseRedFormatting()
+    {
+        var component = new Component
+        {
+            Dependencies = [],
+            Description = "SDK",
+            Key = "sdk-6",
+            Name = "sdk",
+            MajorVersion = 6,
+            IsLts = true,
+            Grade = Grade.Rtm,
+            EndOfLife = DateTime.Now.AddDays(-10)
+        };
+
+        var eol = OutputFormat.Eol(component, installed: false);
+
+        Assert.Contains("red", eol);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `info` command that shows detailed information about a .NET component (installed or available), including status, LTS support, snap grade/channel, end-of-life date, and dependency relationships.

## Usage

```bash
dotnet installer info sdk lts
dotnet installer info runtime 8
```

Invalid or missing arguments fail early with a clear error listing valid components/versions.

## Changes

- **New `info` command** (`Commands/InfoCommand.cs`): renders a panel with the component's status, LTS flag, grade, snap channel, and EOL date, plus dependency and reverse-dependency trees. Validates the component name before the version, so unknown components fail immediately.
- **Shared `OutputFormat` helper**: consolidates status/EOL formatting logic previously embedded in `ListCommand`.
- **`list` command**: new `--installed` and `--lts` filters, with friendly empty-state messages.
- **`install` command**: clearer "component does not exist" error that lists valid components and shows an example.

## Tests

- Adds `OutputFormatTests` covering the status and EOL formatting logic.


<img width="1415" height="220" alt="image" src="https://github.com/user-attachments/assets/9722b41c-adcc-4dd7-b933-72364ffa610c" />

<img width="1391" height="218" alt="image" src="https://github.com/user-attachments/assets/fae9c025-5de3-416f-9107-0e0632769009" />

<img width="1546" height="277" alt="image" src="https://github.com/user-attachments/assets/84856b2e-0da1-489c-b8a5-22f8af330754" />